### PR TITLE
fix: remove stale nolint directive for gosec in anycache.go

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -204,7 +204,7 @@ func (c *Cache) requestHandler() {
 				continue
 			}
 
-			ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in CacheQueue.cancelCtx and called on cleanup
+			ctx, cancel := context.WithCancel(context.Background())
 			requestStorage[req.key] = CacheQueue{
 				requests:  []*CacheReuest{req},
 				cancelCtx: cancel,


### PR DESCRIPTION
## Summary

Removes a stale `//nolint:gosec` directive from `anycache.go`.

The comment was suppressing a `gosec` G118 warning on the `context.WithCancel` call, but that rule no longer fires (likely dropped/updated in a newer version of `gosec`). Since the suppression had no effect, `nolintlint` correctly flagged it as an unused directive.

## Changes
- **`anycache.go`**: Removed `//nolint:gosec // G118: cancel is stored in CacheQueue.cancelCtx and called on cleanup` comment from line 207.

## Linter
```
golangci-lint run ./...
0 issues.
```