### PR TITLE
Refactor public interface to accept context explicitly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.26.x"]
-        redis-version: [5, 6, 7]
+        redis-version: [5, 6, 7, 8]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.x"]
+        go-version: ["1.26.x"]
         redis-version: [5, 6, 7]
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.26
 
 # Set destination for COPY
 WORKDIR /go/src/app

--- a/anycache.go
+++ b/anycache.go
@@ -59,8 +59,10 @@ type CacheQueue struct {
 	WarmingUp    bool
 }
 
-type CacheGenerator func(ctx context.Context) (string, error)
-type CacheOptions func(*Cache)
+type (
+	CacheGenerator func(ctx context.Context) (string, error)
+	CacheOptions   func(*Cache)
+)
 
 type CacheItemOptions func(*CacheReuest)
 
@@ -109,12 +111,6 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 	}
 }
 
-func WithCtx(ctx context.Context) CacheItemOptions {
-	return func(req *CacheReuest) {
-		req.ctx = ctx
-	}
-}
-
 // Cache caches the result of the generator function for the given key.
 // If the key already exists in the cache, the cached value is returned.
 // Otherwise, the generator function is called to generate a new value,
@@ -122,13 +118,13 @@ func WithCtx(ctx context.Context) CacheItemOptions {
 // The function takes an optional list of CacheItemOptions to customize the caching behavior.
 // WithTTL sets TTL for cache item
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
-func (c *Cache) Cache(key string, generator CacheGenerator, opts ...CacheItemOptions) (string, error) {
+func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator, opts ...CacheItemOptions) (string, error) {
 	response := make(chan CacheResponse)
 	req := CacheReuest{
 		key:       key,
 		generator: generator,
 		response:  response,
-		ctx:       context.Background(),
+		ctx:       ctx,
 	}
 
 	for _, opt := range opts {
@@ -138,9 +134,9 @@ func (c *Cache) Cache(key string, generator CacheGenerator, opts ...CacheItemOpt
 	c.requests <- &req
 
 	select {
-	case <-req.ctx.Done():
+	case <-ctx.Done():
 		c.cancel <- &req
-		return "", req.ctx.Err()
+		return "", ctx.Err()
 	case resp := <-response:
 		return resp.value, resp.err
 	}
@@ -154,7 +150,7 @@ func (c *Cache) Cache(key string, generator CacheGenerator, opts ...CacheItemOpt
 // WithTTL sets TTL for cache item
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
 // Returns an error if there was a problem caching or unmarshalling the value.
-func (c *Cache) CacheStruct(key string, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {
+func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {
 	generatorWrapper := func(ctx context.Context) (string, error) {
 		val, err := generator(ctx)
 		if err != nil {
@@ -169,7 +165,7 @@ func (c *Cache) CacheStruct(key string, generator func(context.Context) (any, er
 		return string(jsonVal), nil
 	}
 
-	val, err := c.Cache(key, generatorWrapper, opts...)
+	val, err := c.Cache(ctx, key, generatorWrapper, opts...)
 	if err != nil {
 		return err
 	}

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -67,7 +67,7 @@ func TestCache(t *testing.T) {
 	for storageName, cacheStorage := range getCacheStorages() {
 		cache := NewCache(cacheStorage)
 
-		val, err := cache.Cache("TestCacheKey", getGenerator("testValue", nil))
+		val, err := cache.Cache(t.Context(), "TestCacheKey", getGenerator("testValue", nil))
 		if err != nil {
 			t.Errorf("%v: Expected to get no error, but got %v", storageName, err)
 		}
@@ -76,7 +76,7 @@ func TestCache(t *testing.T) {
 			t.Errorf("%v: Expected to get testValue, but got '%v'", storageName, val)
 		}
 
-		val, err = cache.Cache("TestCacheKey", getGenerator("testValue1", nil))
+		val, err = cache.Cache(t.Context(), "TestCacheKey", getGenerator("testValue1", nil))
 		if err != nil {
 			t.Errorf("%v: Expected to get no error, but got %v", storageName, err)
 		}
@@ -85,7 +85,7 @@ func TestCache(t *testing.T) {
 			t.Errorf("%v: Expected to get testValue, but got '%v'", storageName, val)
 		}
 
-		val, err = cache.Cache("TestCacheKey1", getGenerator("", errors.New("TestError")))
+		val, err = cache.Cache(t.Context(), "TestCacheKey1", getGenerator("", errors.New("TestError")))
 
 		if err == errors.New("TestError") {
 			t.Errorf("%v: Expected to get TestError, but got %v", storageName, err)
@@ -108,7 +108,7 @@ func TestCacheConcurrency(t *testing.T) {
 		results := make(chan string)
 
 		go func(c *Cache, ch chan string) {
-			val, _ := c.Cache("TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
+			val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
 				time.Sleep(time.Millisecond)
 				return "testValue", nil
 			})
@@ -116,7 +116,7 @@ func TestCacheConcurrency(t *testing.T) {
 		}(&cache, results)
 
 		go func(c *Cache, ch chan string) {
-			val, _ := c.Cache("TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
+			val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
 				time.Sleep(time.Millisecond)
 				return "testValue1", nil
 			})
@@ -145,7 +145,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	cacheStore := redisstor.NewRedisCacheStorage(redisClient)
 	cache := NewCache(cacheStore)
 
-	val, err := cache.Cache("TestCacheWarmingUpKey", getGenerator("testValue", nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
+	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", getGenerator("testValue", nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -159,7 +159,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	time.Sleep(time.Millisecond * 1001)
 
 	go func(c *Cache, ch chan string) {
-		val, err := c.Cache("TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
+		val, err := c.Cache(t.Context(), "TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
 			time.Sleep(time.Millisecond * 10)
 			return "newTestValue", nil
 		}, WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
@@ -171,7 +171,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	}(&cache, results)
 
 	go func(c *Cache, ch chan string) {
-		val, err := c.Cache("TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
+		val, err := c.Cache(t.Context(), "TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
 			time.Sleep(time.Millisecond * 10)
 			return "newTestValue", nil
 		}, WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
@@ -227,8 +227,7 @@ func TestCacheJSON(t *testing.T) {
 		var result map[string]string
 
 		// Call the CacheJSON function to cache the test value
-		err := cache.CacheStruct(key, generator, &result)
-
+		err := cache.CacheStruct(t.Context(), key, generator, &result)
 		// Check that the function returned no errors
 		if err != nil {
 			t.Errorf("%v: CacheJSON returned an error: %v", storageName, err)
@@ -240,8 +239,7 @@ func TestCacheJSON(t *testing.T) {
 		}
 
 		// Call the CacheJSON function again to read value from storage
-		err = cache.CacheStruct(key, generator, &result)
-
+		err = cache.CacheStruct(t.Context(), key, generator, &result)
 		// Check that the function returned no errors
 		if err != nil {
 			t.Errorf("%v: CacheJSON returned an error: %v", storageName, err)
@@ -271,7 +269,7 @@ func TestCancelingRequest(t *testing.T) {
 		// Call the CacheJSON function to cache the test value
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 
-		result, err := cache.Cache("TestCancelingRequestKey", generator, WithTTL(2*time.Second), WithCtx(ctx))
+		result, err := cache.Cache(ctx, "TestCancelingRequestKey", generator, WithTTL(2*time.Second))
 
 		// Check that the function returned no errors
 		if !errors.Is(err, context.DeadlineExceeded) {
@@ -309,7 +307,7 @@ func TestClosingOnRequest(t *testing.T) {
 			}
 		}()
 
-		result, err := cache.Cache("TestCancelingRequestKey", generator, WithTTL(2*time.Second))
+		result, err := cache.Cache(t.Context(), "TestCancelingRequestKey", generator, WithTTL(2*time.Second))
 
 		// Check that the function returned no errors
 		if !errors.Is(err, context.Canceled) {
@@ -332,7 +330,7 @@ func TestPerfomance(t *testing.T) {
 		NumberOfKeys      = 400
 	)
 
-	var expectedResults = map[string]time.Duration{
+	expectedResults := map[string]time.Duration{
 		// For Github Actions we have to increase expected timing, on local machine it runs >20X faster
 		"redis":     7 * time.Second,
 		"memcached": 10 * time.Second,
@@ -354,7 +352,7 @@ func TestPerfomance(t *testing.T) {
 					//nolint:gosec // we don't need cryptographically secure random number generator for tesst
 					key := fmt.Sprintf("key%d", rand.Intn(NumberOfKeys))
 
-					_, err := cache.Cache(key, getGenerator(fmt.Sprintf("value%s", key), nil))
+					_, err := cache.Cache(t.Context(), key, getGenerator(fmt.Sprintf("value%s", key), nil))
 					if err != nil {
 						fmt.Printf("Error caching value for key %s: %v\n", key, err)
 						continue

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   tests:
     build: ./
@@ -16,7 +14,7 @@ services:
       - redis
       - memcached
   redis:
-    image: docker.io/bitnami/redis:7.0
+    image: docker.io/redis:8.8
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/anycache
 
-go 1.24.1
+go 1.26.3
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874


### PR DESCRIPTION
This pull request refactors the `Cache` API to require an explicit `context.Context` parameter, improving control over cancellation and timeouts for cache operations. It also removes the `WithCtx` option in favor of directly passing the context, and updates all relevant tests and usage accordingly. Additionally, the Go version in `go.mod` is updated.

**API Refactor:**

* The `Cache` and `CacheStruct` methods in `anycache.go` now require a `context.Context` as the first parameter, making context management explicit and more idiomatic. The internal context handling in these methods is updated to use the passed context. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L112-R127) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L157-R153) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L172-R168) [[4]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L141-R139)
* The `WithCtx` cache option is removed, simplifying the API and eliminating redundant context passing.

**Test Updates:**

* All usages of `Cache` and `CacheStruct` in `anycache_test.go` are updated to pass the test context explicitly, ensuring tests reflect the new API and maintain correct context propagation. [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL70-R70) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL79-R79) [[3]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL88-R88) [[4]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL111-R119) [[5]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL148-R148) [[6]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL162-R162) [[7]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL174-R174) [[8]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL230-R230) [[9]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL243-R242) [[10]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL274-R272) [[11]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL312-R310) [[12]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL357-R355)

**Other Minor Changes:**

* The Go version is updated from 1.24.1 to 1.26.3 in `go.mod`.
* Minor code style improvements, such as using `:=` for variable declaration in tests.