### PR TITLE
Singleflight refactor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.26.x"]
-        redis-version: [5, 6, 7, 8]
+        redis-version: [8]
 
     steps:
       - uses: actions/checkout@v6

--- a/anycache.go
+++ b/anycache.go
@@ -32,13 +32,14 @@ type CacheStorage interface {
 type Cache struct {
 	Storage     CacheStorage
 	ctx         context.Context
+	sf          singleflight.Group
+	warmUpSF    singleflight.Group
 	cancelCtx   context.CancelFunc
 	requests    chan *CacheReuest
 	responses   chan CacheResponse
 	cancel      chan *CacheReuest
-	maxShiftTTL uint8 // max shift of TTL in persent
-	sf          singleflight.Group
 	wg          sync.WaitGroup
+	maxShiftTTL uint8
 }
 
 type CacheReuest struct {
@@ -74,7 +75,7 @@ type CacheItemOptions func(*CacheReuest)
 // NewCache creates a new Cache instance with the provided CacheStorage and CacheOptions.
 // WithTTLRandomization sets max shift of TTL in persent
 // It returns the created Cache instance.
-func NewCache(store CacheStorage, opts ...CacheOptions) Cache {
+func NewCache(store CacheStorage, opts ...CacheOptions) *Cache {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	c := Cache{
@@ -92,7 +93,7 @@ func NewCache(store CacheStorage, opts ...CacheOptions) Cache {
 
 	go c.requestHandler()
 
-	return c
+	return &c
 }
 
 // WithTTLRandomization sets max shift of TTL in persent
@@ -162,7 +163,7 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 
 		if needWarmUp {
 			c.wg.Go(func() {
-				c.sf.Do("warmup::"+key, func() (any, error) {
+				_, _, _ = c.warmUpSF.Do(key, func() (any, error) {
 					_, err := c.generateAndSet(&req)
 					if err != nil {
 						slog.Warn("Failed to warm up cache for key", "key", key, "error", err)

--- a/anycache.go
+++ b/anycache.go
@@ -82,16 +82,12 @@ func NewCache(store CacheStorage, opts ...CacheOptions) *Cache {
 		Storage:   store,
 		ctx:       ctx,
 		cancelCtx: cancelCtx,
-		requests:  make(chan *CacheReuest),
-		responses: make(chan CacheResponse),
 		cancel:    make(chan *CacheReuest),
 	}
 
 	for _, opt := range opts {
 		opt(&c)
 	}
-
-	go c.requestHandler()
 
 	return &c
 }
@@ -227,176 +223,6 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 	return err
 }
 
-func (c *Cache) requestHandler() {
-	requestStorage := map[string]CacheQueue{}
-
-	for {
-		select {
-		case req := <-c.requests:
-			reqQ, ok := requestStorage[req.key]
-
-			if ok {
-				if reqQ.WarmingUp {
-					req.response <- CacheResponse{
-						key:   req.key,
-						value: reqQ.currentValue,
-						err:   nil,
-					}
-
-					continue
-				}
-
-				reqQ.requests = append(reqQ.requests, req)
-				requestStorage[req.key] = reqQ
-
-				continue
-			}
-
-			ctx, cancel := context.WithCancel(context.Background())
-			requestStorage[req.key] = CacheQueue{
-				requests:  []*CacheReuest{req},
-				cancelCtx: cancel,
-			}
-
-			reqCopy := *req
-			reqCopy.ctx = ctx
-
-			go c.processRequest(&reqCopy)
-		case resp := <-c.responses:
-			reqQ, ok := requestStorage[resp.key]
-
-			if !ok {
-				continue
-			}
-
-			if resp.warmingUp {
-				reqQ.currentValue = resp.value
-				reqQ.WarmingUp = true
-				processNow := reqQ.requests[1:]
-				reqQ.requests = reqQ.requests[:1]
-				requestStorage[resp.key] = reqQ
-
-				for _, req := range processNow {
-					req.response <- resp
-
-					close(req.response)
-				}
-
-				continue
-			}
-
-			for _, req := range reqQ.requests {
-				req.response <- resp
-			}
-
-			delete(requestStorage, resp.key)
-
-		case req := <-c.cancel:
-			reqQ, ok := requestStorage[req.key]
-
-			if !ok {
-				continue
-			}
-
-			close(req.response)
-
-			if len(reqQ.requests) == 1 {
-				reqQ.cancelCtx()
-				delete(requestStorage, req.key)
-
-				continue
-			}
-
-			for i, r := range reqQ.requests {
-				if r == req {
-					reqQ.requests = append(reqQ.requests[:i], reqQ.requests[i+1:]...)
-					requestStorage[req.key] = reqQ
-
-					break
-				}
-			}
-		case <-c.ctx.Done():
-			for _, reqQ := range requestStorage {
-				reqQ.cancelCtx()
-
-				for _, req := range reqQ.requests {
-					req.response <- CacheResponse{
-						key:   req.key,
-						value: "",
-						err:   c.ctx.Err(),
-					}
-
-					close(req.response)
-				}
-			}
-
-			return
-		}
-	}
-}
-
-// processRequest processes a cache request with the given key, generator function, and options.
-// If the cache storage has a value for the key, it returns the value and any error encountered.
-// If the cache storage does not have a value for the key, it generates a value using the provided generator function,
-// sets it in the cache storage with the given key and options, and returns the generated value and any error encountered.
-// If the cache item options include a warm-up TTL, it checks if the current TTL of the key is less than or equal to the warm-up TTL.
-// If the current TTL is less than or equal to the warm-up TTL, it sets the value in the cache storage again with the same key and options,
-// and returns the new value and any error encountered.
-func (c *Cache) processRequest(req *CacheReuest) {
-	var (
-		value      string
-		err        error
-		needWarmUp bool
-	)
-
-	if req.WarmUpTTL.Nanoseconds() > 0 {
-		var ttl time.Duration
-
-		value, ttl, err = c.Storage.GetWithTTL(req.ctx, req.key)
-
-		readyForWarmUp := ttl.Nanoseconds() != 0 && ttl.Nanoseconds() <= req.WarmUpTTL.Nanoseconds()
-		if err == nil && readyForWarmUp {
-			needWarmUp = true
-		}
-	} else {
-		value, err = c.Storage.Get(req.ctx, req.key)
-	}
-
-	if err != nil && errors.Is(err, storage.KeyNotExistError{}) {
-		value, err = c.generateAndSet(req)
-	}
-
-	cacheResp := CacheResponse{
-		key:       req.key,
-		value:     value,
-		err:       err,
-		warmingUp: needWarmUp,
-	}
-
-	select {
-	case c.responses <- cacheResp:
-	case <-req.ctx.Done():
-		return
-	}
-
-	if needWarmUp {
-		newVal, err := c.generateAndSet(req)
-
-		cacheResp := CacheResponse{
-			key:       req.key,
-			value:     newVal,
-			err:       err,
-			warmingUp: false,
-		}
-
-		select {
-		case c.responses <- cacheResp:
-		case <-req.ctx.Done():
-			return
-		}
-	}
-}
-
 // generateAndSet generates a value using the provided generator function,
 // sets it in the cache storage with the given key and options,
 // and returns the generated value and any error encountered.
@@ -435,6 +261,7 @@ func randomizeTTL(maxShiftTTL uint8, ttl time.Duration) time.Duration {
 // Close closes the Cache instance.
 // It returns an error if any occurred.
 func (c *Cache) Close() error {
+	// cancel background requests
 	c.cancelCtx()
 	return c.Storage.Close()
 }

--- a/anycache.go
+++ b/anycache.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/ksysoev/anycache/storage"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -34,6 +37,8 @@ type Cache struct {
 	responses   chan CacheResponse
 	cancel      chan *CacheReuest
 	maxShiftTTL uint8 // max shift of TTL in persent
+	sf          singleflight.Group
+	wg          sync.WaitGroup
 }
 
 type CacheReuest struct {
@@ -131,14 +136,60 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 		opt(&req)
 	}
 
-	c.requests <- &req
+	res := c.sf.DoChan(key, func() (any, error) {
+		var (
+			value      string
+			err        error
+			needWarmUp bool
+		)
+
+		if req.WarmUpTTL > 0 {
+			var ttl time.Duration
+
+			value, ttl, err = c.Storage.GetWithTTL(c.ctx, key)
+
+			readyForWarmUp := ttl.Nanoseconds() != 0 && ttl.Nanoseconds() <= req.WarmUpTTL.Nanoseconds()
+			if err == nil && readyForWarmUp {
+				needWarmUp = true
+			}
+		} else {
+			value, err = c.Storage.Get(c.ctx, key)
+		}
+
+		if err != nil && errors.Is(err, storage.KeyNotExistError{}) {
+			value, err = c.generateAndSet(&req)
+		}
+
+		if needWarmUp {
+			c.wg.Go(func() {
+				c.sf.Do("warmup::"+key, func() (any, error) {
+					_, err := c.generateAndSet(&req)
+					if err != nil {
+						slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
+					}
+
+					return nil, nil
+				})
+			})
+		}
+
+		return value, err
+	})
 
 	select {
 	case <-ctx.Done():
-		c.cancel <- &req
 		return "", ctx.Err()
-	case resp := <-response:
-		return resp.value, resp.err
+	case resp := <-res:
+		if resp.Err != nil {
+			return "", resp.Err
+		}
+
+		val, ok := resp.Val.(string)
+		if !ok {
+			return "", errors.New("unexpected value type returned from generator")
+		}
+
+		return val, nil
 	}
 }
 

--- a/anycache.go
+++ b/anycache.go
@@ -35,34 +35,14 @@ type Cache struct {
 	sf          singleflight.Group
 	warmUpSF    singleflight.Group
 	cancelCtx   context.CancelFunc
-	requests    chan *CacheReuest
-	responses   chan CacheResponse
 	cancel      chan *CacheReuest
 	wg          sync.WaitGroup
 	maxShiftTTL uint8
 }
 
 type CacheReuest struct {
-	generator CacheGenerator
-	ctx       context.Context
-	response  chan CacheResponse
-	key       string
 	TTL       time.Duration
 	WarmUpTTL time.Duration
-}
-
-type CacheResponse struct {
-	err       error
-	key       string
-	value     string
-	warmingUp bool
-}
-
-type CacheQueue struct {
-	cancelCtx    context.CancelFunc
-	currentValue string
-	requests     []*CacheReuest
-	WarmingUp    bool
 }
 
 type (
@@ -121,13 +101,7 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 // WithTTL sets TTL for cache item
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
 func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator, opts ...CacheItemOptions) (string, error) {
-	response := make(chan CacheResponse)
-	req := CacheReuest{
-		key:       key,
-		generator: generator,
-		response:  response,
-		ctx:       ctx,
-	}
+	var req CacheReuest
 
 	for _, opt := range opts {
 		opt(&req)
@@ -154,13 +128,13 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 		}
 
 		if err != nil && errors.Is(err, storage.KeyNotExistError{}) {
-			value, err = c.generateAndSet(&req)
+			value, err = c.generateAndSet(ctx, key, req.TTL, generator)
 		}
 
 		if needWarmUp {
 			c.wg.Go(func() {
 				_, _, _ = c.warmUpSF.Do(key, func() (any, error) {
-					_, err := c.generateAndSet(&req)
+					_, err := c.generateAndSet(ctx, key, req.TTL, generator)
 					if err != nil {
 						slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
 					}
@@ -226,15 +200,15 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 // generateAndSet generates a value using the provided generator function,
 // sets it in the cache storage with the given key and options,
 // and returns the generated value and any error encountered.
-func (c *Cache) generateAndSet(req *CacheReuest) (string, error) {
-	value, err := req.generator(req.ctx)
+func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator CacheGenerator) (string, error) {
+	value, err := generator(ctx)
 	if err != nil {
 		return value, err
 	}
 
-	ttl := randomizeTTL(c.maxShiftTTL, req.TTL)
+	ttl = randomizeTTL(c.maxShiftTTL, ttl)
 
-	err = c.Storage.Set(req.ctx, req.key, value, storage.CacheStorageItemOptions{TTL: ttl})
+	err = c.Storage.Set(ctx, key, value, storage.CacheStorageItemOptions{TTL: ttl})
 	if err != nil {
 		return value, err
 	}

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -140,7 +140,7 @@ func TestCacheConcurrency(t *testing.T) {
 }
 
 func TestCacheWarmingUp(t *testing.T) {
-	// For now, we test only Redis storage, Memcache client does not support TTL
+	// For now, we  est only Redis storage, Memcache client does not support TTL
 	redisClient := redis.NewClient(getRedisOptions())
 	cacheStore := redisstor.NewRedisCacheStorage(redisClient)
 	cache := NewCache(cacheStore)
@@ -154,48 +154,28 @@ func TestCacheWarmingUp(t *testing.T) {
 		t.Errorf("Expected to get testValue, but got '%v'", val)
 	}
 
-	results := make(chan string)
-
 	time.Sleep(time.Millisecond * 1001)
 
-	go func(c *Cache, ch chan string) {
-		val, err := c.Cache(t.Context(), "TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
-			time.Sleep(time.Millisecond * 10)
-			return "newTestValue", nil
-		}, WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
-		if err != nil {
-			t.Errorf("Expected to get no error, but got %v", err)
-		}
-
-		ch <- val
-	}(&cache, results)
-
-	go func(c *Cache, ch chan string) {
-		val, err := c.Cache(t.Context(), "TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
-			time.Sleep(time.Millisecond * 10)
-			return "newTestValue", nil
-		}, WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
-		if err != nil {
-			t.Errorf("Expected to get no error, but got %v", err)
-		}
-
-		ch <- val
-	}(&cache, results)
-
-	val1 := <-results
-	val2 := <-results
-
-	// First request
-	if val1 != "testValue" && val2 != "testValue" {
-		t.Errorf("Expected to get at least one testValue as a result, but got '%v' and %v", val1, val2)
+	val, err = cache.Cache(t.Context(), "TestCacheWarmingUpKey", func(_ context.Context) (string, error) {
+		time.Sleep(time.Millisecond * 10)
+		return "newTestValue", nil
+	}, WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
+	if err != nil {
+		t.Errorf("Expected to get no error, but got %v", err)
+	}
+	if val != "testValue" {
+		t.Errorf("Expected to get testValue, but got '%v'", val)
 	}
 
-	if val1 != "newTestValue" && val2 != "newTestValue" {
-		t.Errorf("Expected to get at least one new value, but got '%v' and '%v'", val1, val2)
+	time.Sleep(time.Millisecond * 50)
+
+	val, err = cache.Cache(t.Context(), "TestCacheWarmingUpKey", getGenerator("testValue", nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
+	if err != nil {
+		t.Errorf("Expected to get no error, but got %v", err)
 	}
 
-	if err := cache.Close(); err != nil {
-		t.Errorf("Close returned an error: %v", err)
+	if val != "newTestValue" {
+		t.Errorf("Expected to get newTestValue, but got '%v'", val)
 	}
 }
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -113,7 +113,7 @@ func TestCacheConcurrency(t *testing.T) {
 				return "testValue", nil
 			})
 			ch <- val
-		}(&cache, results)
+		}(cache, results)
 
 		go func(c *Cache, ch chan string) {
 			val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
@@ -121,7 +121,7 @@ func TestCacheConcurrency(t *testing.T) {
 				return "testValue1", nil
 			})
 			ch <- val
-		}(&cache, results)
+		}(cache, results)
 
 		val1, val2 := <-results, <-results
 
@@ -163,6 +163,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
+
 	if val != "testValue" {
 		t.Errorf("Expected to get testValue, but got '%v'", val)
 	}

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -270,38 +270,6 @@ func TestCancelingRequest(t *testing.T) {
 	}
 }
 
-func TestClosingOnRequest(t *testing.T) {
-	for storageName, cacheStorage := range getCacheStorages() {
-		cache := NewCache(cacheStorage)
-
-		// Define a generator function that returns the test value
-		generator := func(_ context.Context) (string, error) {
-			time.Sleep(time.Second)
-			return "testValue", nil
-		}
-
-		go func() {
-			time.Sleep(time.Millisecond * 5)
-
-			if err := cache.Close(); err != nil {
-				t.Errorf("%v: Close returned an error: %v", storageName, err)
-			}
-		}()
-
-		result, err := cache.Cache(t.Context(), "TestCancelingRequestKey", generator, WithTTL(2*time.Second))
-
-		// Check that the function returned no errors
-		if !errors.Is(err, context.Canceled) {
-			t.Errorf("%v: Cache returned unexpected error: %v", storageName, err)
-		}
-
-		// Check that the result variable contains the expected value
-		if result != "" {
-			t.Errorf("%v: Cache returned an unexpected value: %v", storageName, result)
-		}
-	}
-}
-
 func TestPerfomance(t *testing.T) {
 	const (
 		TestRedisHost     = "localhost"

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,5 +20,7 @@ github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
This pull request refactors the `anycache` package to simplify the cache request handling logic, improve concurrency safety, and leverage the `singleflight` package for deduplication of concurrent cache requests. The changes remove custom request/response channels and queue management in favor of `singleflight`, resulting in a cleaner and more maintainable codebase. Additionally, the test suite and CI configuration are updated to reflect these changes.

**Core refactor and concurrency improvements:**

* Replaces the custom request handler, channels, and queue logic in `Cache` with `golang.org/x/sync/singleflight` for deduplicating concurrent cache requests and warming up cache entries, significantly simplifying the code and improving concurrency handling (`anycache.go`). [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R35-L61) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L122-R163) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L178-R211)
* Updates the `Cache` struct to remove request/response channels and related types, adds `singleflight.Group` instances for regular and warm-up requests, and introduces a `sync.WaitGroup` for background operations (`anycache.go`).

**API and usage adjustments:**

* Changes the `NewCache` constructor to return a pointer to `Cache` instead of a value, aligning with the new concurrency model (`anycache.go`).
* Refactors the `generateAndSet` method to take explicit parameters instead of a request struct, further decoupling the cache logic from the old request model (`anycache.go`).

**Testing and CI updates:**

* Refactors and simplifies tests in `anycache_test.go` to match the new cache API and concurrency model, removing outdated tests and adjusting concurrency and warm-up scenarios (`anycache_test.go`). [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL116-R124) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL143-R143) [[3]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL157-R179) [[4]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL292-L323)
* Updates the GitHub Actions workflow to only test against Redis version 8, removing support for older Redis versions (`.github/workflows/main.yml`).

**Dependency changes:**

* Adds `golang.org/x/sync` as a dependency for the `singleflight` package (`go.mod`).