### PR TITLE
Adds Cache invalidation function

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -208,13 +208,9 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 // accepts a context and the key to be invalidated.
 // returns an error if there was a problem invalidating the cache for the key.
 func (c *Cache) Invalidate(ctx context.Context, key string) error {
-	deleted, err := c.Storage.Del(ctx, key)
+	_, err := c.Storage.Del(ctx, key)
 	if err != nil {
 		return fmt.Errorf("failed to invalidate cache for key %s: %w", key, err)
-	}
-
-	if !deleted {
-		return fmt.Errorf("cache key %s: %w", key, ErrKeyNotExists)
 	}
 
 	return nil

--- a/anycache.go
+++ b/anycache.go
@@ -27,7 +27,6 @@ type CacheStorage interface {
 	TTL(context.Context, string) (bool, time.Duration, error)
 	Del(context.Context, string) (bool, error)
 	GetWithTTL(context.Context, string) (string, time.Duration, error)
-	Close() error
 }
 
 // Cache
@@ -203,6 +202,18 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 	err = json.Unmarshal([]byte(val), result)
 
 	return err
+}
+
+// Invalidate removes the cached value for the given key from the cache storage.
+// accepts a context and the key to be invalidated.
+// returns an error if there was a problem invalidating the cache for the key.
+func (c *Cache) Invalidate(ctx context.Context, key string) error {
+	_, err := c.Storage.Del(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to invalidate cache for key %s: %w", key, err)
+	}
+
+	return nil
 }
 
 // generateAndSet generates a value using the provided generator function,

--- a/anycache.go
+++ b/anycache.go
@@ -208,9 +208,13 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 // accepts a context and the key to be invalidated.
 // returns an error if there was a problem invalidating the cache for the key.
 func (c *Cache) Invalidate(ctx context.Context, key string) error {
-	_, err := c.Storage.Del(ctx, key)
+	deleted, err := c.Storage.Del(ctx, key)
 	if err != nil {
 		return fmt.Errorf("failed to invalidate cache for key %s: %w", key, err)
+	}
+
+	if !deleted {
+		return fmt.Errorf("cache key %s: %w", key, ErrKeyNotExists)
 	}
 
 	return nil

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -172,4 +173,55 @@ func TestCancelingRequest(t *testing.T) {
 	}
 
 	time.Sleep(time.Millisecond * 10) // watch to finish set on mock
+}
+
+func TestCache_Invalidate(t *testing.T) {
+	tests := []struct {
+		setup   func() CacheStorage
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{
+			name:    "Invalidate key successfully",
+			key:     "TestInvalidateKey",
+			wantErr: false,
+			setup: func() CacheStorage {
+				store := NewMockCacheStorage(t)
+				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(true, nil)
+
+				return store
+			},
+		},
+		{
+			name:    "Invalidate key with error",
+			key:     "TestInvalidateKey",
+			wantErr: true,
+			setup: func() CacheStorage {
+				store := NewMockCacheStorage(t)
+				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(false, assert.AnError)
+
+				return store
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := tt.setup()
+			c := NewCache(store)
+
+			gotErr := c.Invalidate(context.Background(), tt.key)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("Invalidate() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("Invalidate() succeeded unexpectedly")
+			}
+		})
+	}
 }

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -204,13 +204,24 @@ func TestCache_Invalidate(t *testing.T) {
 				return store
 			},
 		},
+		{
+			name:    "Invalidate missing key",
+			key:     "TestInvalidateNotExistingKey",
+			wantErr: false,
+			setup: func() CacheStorage {
+				store := NewMockCacheStorage(t)
+				store.EXPECT().Del(mock.Anything, "TestInvalidateNotExistingKey").Return(false, nil)
+
+				return store
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := tt.setup()
 			c := NewCache(store)
 
-			gotErr := c.Invalidate(context.Background(), tt.key)
+			gotErr := c.Invalidate(t.Context(), tt.key)
 			if gotErr != nil {
 				if !tt.wantErr {
 					t.Errorf("Invalidate() failed: %v", gotErr)

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -180,12 +180,12 @@ func TestCache_Invalidate(t *testing.T) {
 		setup   func() CacheStorage
 		name    string
 		key     string
-		wantErr error
+		wantErr bool
 	}{
 		{
 			name:    "Invalidate key successfully",
 			key:     "TestInvalidateKey",
-			wantErr: nil,
+			wantErr: false,
 			setup: func() CacheStorage {
 				store := NewMockCacheStorage(t)
 				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(true, nil)
@@ -196,21 +196,10 @@ func TestCache_Invalidate(t *testing.T) {
 		{
 			name:    "Invalidate key with error",
 			key:     "TestInvalidateKey",
-			wantErr: assert.AnError,
+			wantErr: true,
 			setup: func() CacheStorage {
 				store := NewMockCacheStorage(t)
 				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(false, assert.AnError)
-
-				return store
-			},
-		},
-		{
-			name:    "Invalidate non-existing key",
-			key:     "TestInvalidateKey",
-			wantErr: ErrKeyNotExists,
-			setup: func() CacheStorage {
-				store := NewMockCacheStorage(t)
-				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(false, nil)
 
 				return store
 			},
@@ -223,15 +212,15 @@ func TestCache_Invalidate(t *testing.T) {
 
 			gotErr := c.Invalidate(context.Background(), tt.key)
 			if gotErr != nil {
-				if isError := errors.Is(gotErr, tt.wantErr); !isError {
-					t.Errorf("Expected error '%v', but got '%v'", tt.wantErr, gotErr)
+				if !tt.wantErr {
+					t.Errorf("Invalidate() failed: %v", gotErr)
 				}
 
 				return
 			}
 
-			if tt.wantErr != nil {
-				t.Fatal("Expected an error, but got nil")
+			if tt.wantErr {
+				t.Fatal("Invalidate() succeeded unexpectedly")
 			}
 		})
 	}

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -180,12 +180,12 @@ func TestCache_Invalidate(t *testing.T) {
 		setup   func() CacheStorage
 		name    string
 		key     string
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name:    "Invalidate key successfully",
 			key:     "TestInvalidateKey",
-			wantErr: false,
+			wantErr: nil,
 			setup: func() CacheStorage {
 				store := NewMockCacheStorage(t)
 				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(true, nil)
@@ -196,10 +196,21 @@ func TestCache_Invalidate(t *testing.T) {
 		{
 			name:    "Invalidate key with error",
 			key:     "TestInvalidateKey",
-			wantErr: true,
+			wantErr: assert.AnError,
 			setup: func() CacheStorage {
 				store := NewMockCacheStorage(t)
 				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(false, assert.AnError)
+
+				return store
+			},
+		},
+		{
+			name:    "Invalidate non-existing key",
+			key:     "TestInvalidateKey",
+			wantErr: ErrKeyNotExists,
+			setup: func() CacheStorage {
+				store := NewMockCacheStorage(t)
+				store.EXPECT().Del(mock.Anything, "TestInvalidateKey").Return(false, nil)
 
 				return store
 			},
@@ -212,15 +223,15 @@ func TestCache_Invalidate(t *testing.T) {
 
 			gotErr := c.Invalidate(context.Background(), tt.key)
 			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("Invalidate() failed: %v", gotErr)
+				if isError := errors.Is(gotErr, tt.wantErr); !isError {
+					t.Errorf("Expected error '%v', but got '%v'", tt.wantErr, gotErr)
 				}
 
 				return
 			}
 
-			if tt.wantErr {
-				t.Fatal("Invalidate() succeeded unexpectedly")
+			if tt.wantErr != nil {
+				t.Fatal("Expected an error, but got nil")
 			}
 		})
 	}


### PR DESCRIPTION
This pull request introduces a new method to the `Cache` type for invalidating cached values and adds corresponding unit tests. It also includes a minor cleanup of unused interface methods and improves test dependencies.

**New cache invalidation functionality:**

* Added an `Invalidate` method to the `Cache` struct, allowing users to remove a cached value for a given key and handle errors if cache invalidation fails.
* Removed the unused `Close()` method from the `CacheStorage` interface, simplifying the interface.

**Testing improvements:**

* Added a comprehensive `TestCache_Invalidate` unit test to verify both successful and error scenarios for the new `Invalidate` method.
* Added `testify/assert` to the test imports for improved assertion handling in tests.