### PR TITLE
Inmemory storage

### DIFF
--- a/storage/inmemory/expiryq.go
+++ b/storage/inmemory/expiryq.go
@@ -2,14 +2,20 @@ package inmemory
 
 type expiryQueue []*cacheItem
 
-func (e expiryQueue) Len() int           { return len(e) }
+// Len, Less, and Swap implement the heap.Interface for expiryQueue.
+func (e expiryQueue) Len() int { return len(e) }
+
+// Less returns true if the expiry time of the item at index i is before the expiry time of the item at index j.
 func (e expiryQueue) Less(i, j int) bool { return e[i].expiry.Before(*e[j].expiry) }
+
+// Swap swaps the items at indices i and j and updates their expiryPos fields accordingly.
 func (e expiryQueue) Swap(i, j int) {
 	e[i], e[j] = e[j], e[i]
 	e[i].expiryPos = i
 	e[j].expiryPos = j
 }
 
+// Push adds a new item to the expiryQueue and updates its expiryPos field to reflect its position in the queue.
 func (e *expiryQueue) Push(x any) {
 	n := len(*e)
 	item, _ := x.(*cacheItem)
@@ -17,6 +23,7 @@ func (e *expiryQueue) Push(x any) {
 	item.expiryPos = n
 }
 
+// Pop removes and returns the item with the earliest expiry time from the expiryQueue, updates its expiryPos field to -1, and returns it.
 func (e *expiryQueue) Pop() any {
 	old := *e
 	n := len(old)

--- a/storage/inmemory/expiryq.go
+++ b/storage/inmemory/expiryq.go
@@ -1,0 +1,29 @@
+package inmemory
+
+type expiryQueue []*cacheItem
+
+func (e expiryQueue) Len() int           { return len(e) }
+func (e expiryQueue) Less(i, j int) bool { return e[i].expiry.Before(*e[j].expiry) }
+func (e expiryQueue) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+	e[i].expiryPos = i
+	e[j].expiryPos = j
+}
+
+func (e *expiryQueue) Push(x any) {
+	n := len(*e)
+	item, _ := x.(*cacheItem)
+	*e = append(*e, item)
+	item.expiryPos = n
+}
+
+func (e *expiryQueue) Pop() any {
+	old := *e
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.expiryPos = -1
+	*e = old[0 : n-1]
+
+	return item
+}

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -15,32 +15,32 @@ type cacheItem struct {
 	value  []byte
 }
 
-type InMemoryCacheStorage struct {
+type Storage struct {
 	index map[string]*list.Element
 	items *list.List
 	limit uint
 	mu    sync.RWMutex
 }
 
-func New(limit uint) (*InMemoryCacheStorage, error) {
+func New(limit uint) (*Storage, error) {
 	if limit == 0 {
 		return nil, errors.New("limit must be greater than 0")
 	}
 
-	return &InMemoryCacheStorage{
+	return &Storage{
 		index: map[string]*list.Element{},
 		items: list.New(),
 		limit: limit,
 	}, nil
 }
 
-func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error) {
+func (s *Storage) Get(_ context.Context, key string) (string, error) {
 	value, _, err := s.GetWithTTL(context.Background(), key)
 
 	return value, err
 }
 
-func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, ttl time.Duration) error {
+func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) error {
 	if ttl < 0 {
 		return errors.New("ttl must be non-negative")
 	}
@@ -70,7 +70,7 @@ func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, 
 	return nil
 }
 
-func (s *InMemoryCacheStorage) TTL(_ context.Context, key string) (bool, time.Duration, error) {
+func (s *Storage) TTL(_ context.Context, key string) (bool, time.Duration, error) {
 	_, ttl, err := s.GetWithTTL(context.Background(), key)
 	if err != nil {
 		return false, 0, err
@@ -83,7 +83,7 @@ func (s *InMemoryCacheStorage) TTL(_ context.Context, key string) (bool, time.Du
 	return true, ttl, nil
 }
 
-func (s *InMemoryCacheStorage) Del(_ context.Context, key string) (bool, error) {
+func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -106,7 +106,7 @@ func (s *InMemoryCacheStorage) Del(_ context.Context, key string) (bool, error) 
 	return true, nil
 }
 
-func (s *InMemoryCacheStorage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
+func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -72,6 +72,10 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if existing, ok := s.index[key]; ok {
+		s.delete(existing)
+	}
+
 	if len(s.index) >= s.limit {
 		leastUsed := s.items.Front()
 		item, _ := leastUsed.Value.(*cacheItem)

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -3,6 +3,7 @@ package inmemory
 import (
 	"container/list"
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -15,16 +16,22 @@ type cacheItem struct {
 }
 
 type InMemoryCacheStorage struct {
+	limit uint
 	index map[string]*list.Element
 	items *list.List
 	mu    sync.RWMutex
 }
 
-func New() *InMemoryCacheStorage {
+func New(limit uint) (*InMemoryCacheStorage, error) {
+	if limit == 0 {
+		return nil, errors.New("limit must be greater than 0")
+	}
+
 	return &InMemoryCacheStorage{
 		index: map[string]*list.Element{},
 		items: list.New(),
-	}
+		limit: limit,
+	}, nil
 }
 
 func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error) {

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -26,11 +26,11 @@ type Storage struct {
 	cancel  context.CancelFunc
 	expiryQ expiryQueue
 	wg      sync.WaitGroup
-	limit   uint
+	limit   int
 	mu      sync.RWMutex
 }
 
-func New(limit uint) (*Storage, error) {
+func New(limit int) (*Storage, error) {
 	if limit == 0 {
 		return nil, errors.New("limit must be greater than 0")
 	}
@@ -72,6 +72,12 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if len(s.index) >= s.limit {
+		leastUsed := s.items.Front()
+		item, _ := leastUsed.Value.(*cacheItem)
+		s.delete(item)
+	}
+
 	var expiry *time.Time
 
 	if ttl > 0 {
@@ -79,15 +85,16 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 		expiry = &expTime
 	}
 
-	elem := &list.Element{
-		Value: key,
-	}
-
 	item := &cacheItem{
 		value:  []byte(value),
 		expiry: expiry,
-		lruPos: elem,
 	}
+
+	elem := &list.Element{
+		Value: item,
+	}
+
+	item.lruPos = elem
 
 	s.index[key] = item
 	s.items.PushBack(elem)
@@ -161,6 +168,8 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 
 		return "", 0, anycache.ErrKeyNotExists
 	}
+
+	s.items.MoveToBack(item.lruPos)
 
 	return string(item.value), ttl, nil
 }

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -1,22 +1,27 @@
 package inmemory
 
 import (
+	"container/list"
 	"context"
+	"sync"
 	"time"
 )
 
-// type CacheStorage interface {
-// 	Get(context.Context, string) (string, error)
-// 	Set(context.Context, string, string, time.Duration) error
-// 	TTL(context.Context, string) (bool, time.Duration, error)
-// 	Del(context.Context, string) (bool, error)
-// 	GetWithTTL(context.Context, string) (string, time.Duration, error)
-// }
+type cacheItem struct {
+	value  []byte
+	expiry *time.Time
+}
 
-type InMemoryCacheStorage struct{}
+type InMemoryCacheStorage struct {
+	index *sync.Map
+	items *list.List
+}
 
 func New() *InMemoryCacheStorage {
-	return &InMemoryCacheStorage{}
+	return &InMemoryCacheStorage{
+		index: &sync.Map{},
+		items: list.New(),
+	}
 }
 
 func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error) {
@@ -24,6 +29,21 @@ func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error
 }
 
 func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, ttl time.Duration) error {
+	var expiry *time.Time
+
+	if ttl > 0 {
+		now := time.Now().Add(ttl)
+		expiry = &now
+	}
+
+	storageItem := &cacheItem{
+		[]byte(value),
+		expiry,
+	}
+
+	s.index.Store(key, storageItem)
+	s.items.PushBack(storageItem)
+
 	return nil
 }
 

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -1,6 +1,7 @@
 package inmemory
 
 import (
+	"container/heap"
 	"container/list"
 	"context"
 	"errors"
@@ -11,15 +12,19 @@ import (
 )
 
 type cacheItem struct {
-	expiry *time.Time
-	value  []byte
+	key       string
+	expiry    *time.Time
+	value     []byte
+	expiryPos int
+	lruPos    list.Element
 }
 
 type Storage struct {
-	index map[string]*list.Element
-	items *list.List
-	limit uint
-	mu    sync.RWMutex
+	index   map[string]*cacheItem
+	items   *list.List
+	expiryQ expiryQueue
+	limit   uint
+	mu      sync.RWMutex
 }
 
 func New(limit uint) (*Storage, error) {
@@ -27,10 +32,14 @@ func New(limit uint) (*Storage, error) {
 		return nil, errors.New("limit must be greater than 0")
 	}
 
+	expiryQ := make(expiryQueue, 0, limit)
+	heap.Init(&expiryQ)
+
 	return &Storage{
-		index: map[string]*list.Element{},
-		items: list.New(),
-		limit: limit,
+		index:   make(map[string]*cacheItem, limit),
+		items:   list.New(),
+		limit:   limit,
+		expiryQ: expiryQ,
 	}, nil
 }
 
@@ -51,21 +60,22 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 	var expiry *time.Time
 
 	if ttl > 0 {
-		now := time.Now().Add(ttl)
-		expiry = &now
+		expTime := time.Now().Add(ttl)
+		expiry = &expTime
 	}
 
-	storageItem := &cacheItem{
+	elem := &list.Element{
+		Value: key,
+	}
+
+	item := &cacheItem{
 		value:  []byte(value),
 		expiry: expiry,
 	}
 
-	elem := &list.Element{
-		Value: storageItem,
-	}
-
-	s.index[key] = elem
+	s.index[key] = item
 	s.items.PushBack(elem)
+	s.expiryQ.Push(item)
 
 	return nil
 }

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -20,9 +20,12 @@ type cacheItem struct {
 }
 
 type Storage struct {
+	ctx     context.Context
 	index   map[string]*cacheItem
 	items   *list.List
+	cancel  context.CancelFunc
 	expiryQ expiryQueue
+	wg      sync.WaitGroup
 	limit   uint
 	mu      sync.RWMutex
 }
@@ -32,15 +35,23 @@ func New(limit uint) (*Storage, error) {
 		return nil, errors.New("limit must be greater than 0")
 	}
 
+	cancelCtx, cancel := context.WithCancel(context.Background())
+
 	expiryQ := make(expiryQueue, 0, limit)
 	heap.Init(&expiryQ)
 
-	return &Storage{
+	s := &Storage{
 		index:   make(map[string]*cacheItem, limit),
 		items:   list.New(),
 		limit:   limit,
 		expiryQ: expiryQ,
-	}, nil
+		ctx:     cancelCtx,
+		cancel:  cancel,
+	}
+
+	s.wg.Go(s.expiryLoop)
+
+	return s, nil
 }
 
 func (s *Storage) Get(_ context.Context, key string) (string, error) {
@@ -50,6 +61,10 @@ func (s *Storage) Get(_ context.Context, key string) (string, error) {
 }
 
 func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) error {
+	if s.ctx.Err() != nil {
+		return errors.New("storage is closed")
+	}
+
 	if ttl < 0 {
 		return errors.New("ttl must be non-negative")
 	}
@@ -95,6 +110,10 @@ func (s *Storage) TTL(_ context.Context, key string) (bool, time.Duration, error
 }
 
 func (s *Storage) Del(_ context.Context, key string) (bool, error) {
+	if s.ctx.Err() != nil {
+		return false, errors.New("storage is closed")
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -119,6 +138,10 @@ func (s *Storage) delete(item *cacheItem) {
 }
 
 func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
+	if s.ctx.Err() != nil {
+		return "", 0, errors.New("storage is closed")
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -142,6 +165,39 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 	return string(item.value), ttl, nil
 }
 
-func Close() error {
+func (s *Storage) expiryLoop() {
+	ticker := time.NewTicker(time.Second)
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			if s.expiryQ.Len() == 0 {
+				continue
+			}
+
+			for {
+				item := s.expiryQ[0]
+				if time.Until(*item.expiry) > 0 {
+					break
+				}
+
+				s.delete(item)
+			}
+			s.mu.Unlock()
+		}
+	}
+}
+
+func (s *Storage) Close() error {
+	if s.ctx.Err() != nil {
+		return errors.New("storage is already closed")
+	}
+
+	s.cancel()
+	s.wg.Wait()
+
 	return nil
 }

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -30,6 +30,7 @@ type Storage struct {
 	mu      sync.Mutex
 }
 
+// New creates a new in-memory cache storage with the specified limit on the number of items.
 func New(limit int) (*Storage, error) {
 	if limit == 0 {
 		return nil, errors.New("limit must be greater than 0")
@@ -54,12 +55,14 @@ func New(limit int) (*Storage, error) {
 	return s, nil
 }
 
+// Get retrieves the value associated with the provided key from the in-memory cache storage.
 func (s *Storage) Get(_ context.Context, key string) (string, error) {
 	value, _, err := s.GetWithTTL(context.Background(), key)
 
 	return value, err
 }
 
+// Set stores a value associated with the provided key in the in-memory cache storage.
 func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) error {
 	if s.ctx.Err() != nil {
 		return errors.New("storage is closed")
@@ -107,6 +110,7 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 	return nil
 }
 
+// TTL retrieves the time-to-live (TTL) associated with the provided key from the in-memory cache storage.
 func (s *Storage) TTL(_ context.Context, key string) (bool, time.Duration, error) {
 	_, ttl, err := s.GetWithTTL(context.Background(), key)
 	if err != nil {
@@ -120,6 +124,7 @@ func (s *Storage) TTL(_ context.Context, key string) (bool, time.Duration, error
 	return true, ttl, nil
 }
 
+// Del deletes the value associated with the provided key from the in-memory cache storage.
 func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 	if s.ctx.Err() != nil {
 		return false, errors.New("storage is closed")
@@ -143,15 +148,7 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 	return true, nil
 }
 
-func (s *Storage) delete(item *cacheItem) {
-	delete(s.index, item.key)
-	s.items.Remove(item.lruPos)
-
-	if item.expiryPos >= 0 {
-		heap.Remove(&s.expiryQ, item.expiryPos)
-	}
-}
-
+// GetWithTTL retrieves the value and time-to-live (TTL) associated with the provided key from the in-memory cache storage.
 func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
 	if s.ctx.Err() != nil {
 		return "", 0, errors.New("storage is closed")
@@ -183,6 +180,29 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 	return string(item.value), ttl, nil
 }
 
+// Close gracefully shuts down the in-memory cache storage, ensuring that all resources are released and any ongoing operations are completed.
+func (s *Storage) Close() error {
+	if s.ctx.Err() != nil {
+		return errors.New("storage is already closed")
+	}
+
+	s.cancel()
+	s.wg.Wait()
+
+	return nil
+}
+
+// delete removes the item from the cache, including the index, LRU list, and expiry queue.
+func (s *Storage) delete(item *cacheItem) {
+	delete(s.index, item.key)
+	s.items.Remove(item.lruPos)
+
+	if item.expiryPos >= 0 {
+		heap.Remove(&s.expiryQ, item.expiryPos)
+	}
+}
+
+// expiryLoop continuously checks for expired items in the cache and removes them.
 func (s *Storage) expiryLoop() {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -205,15 +225,4 @@ func (s *Storage) expiryLoop() {
 			s.mu.Unlock()
 		}
 	}
-}
-
-func (s *Storage) Close() error {
-	if s.ctx.Err() != nil {
-		return errors.New("storage is already closed")
-	}
-
-	s.cancel()
-	s.wg.Wait()
-
-	return nil
 }

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -27,7 +27,7 @@ type Storage struct {
 	expiryQ expiryQueue
 	wg      sync.WaitGroup
 	limit   int
-	mu      sync.RWMutex
+	mu      sync.Mutex
 }
 
 func New(limit int) (*Storage, error) {
@@ -157,8 +157,8 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 		return "", 0, errors.New("storage is closed")
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	item, ok := s.index[key]
 

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -12,11 +12,11 @@ import (
 )
 
 type cacheItem struct {
-	key       string
 	expiry    *time.Time
+	lruPos    *list.Element
+	key       string
 	value     []byte
 	expiryPos int
-	lruPos    list.Element
 }
 
 type Storage struct {
@@ -71,6 +71,7 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 	item := &cacheItem{
 		value:  []byte(value),
 		expiry: expiry,
+		lruPos: elem,
 	}
 
 	s.index[key] = item
@@ -97,23 +98,24 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	elem, ok := s.index[key]
-
+	item, ok := s.index[key]
 	if !ok {
 		return false, nil
 	}
 
-	_, err := exractItem(*elem)
-
-	delete(s.index, key)
-
-	s.items.Remove(elem)
-
-	if errors.Is(err, anycache.ErrKeyNotExists) {
+	if item.expiry != nil && time.Until(*item.expiry) <= 0 {
 		return false, nil
 	}
 
+	s.delete(item)
+
 	return true, nil
+}
+
+func (s *Storage) delete(item *cacheItem) {
+	delete(s.index, item.key)
+	s.items.Remove(item.lruPos)
+	heap.Remove(&s.expiryQ, item.expiryPos)
 }
 
 func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
@@ -126,43 +128,18 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 		return "", 0, anycache.ErrKeyNotExists
 	}
 
-	cacheItem, err := exractItem(*item)
-
-	switch {
-	case errors.Is(err, anycache.ErrKeyNotExists):
-		delete(s.index, key)
-		s.items.Remove(item)
-
-		return "", 0, err
-	case err != nil:
-		return "", 0, err
+	if item.expiry == nil {
+		return string(item.value), 0, nil
 	}
 
-	var ttl time.Duration
-	if cacheItem.expiry != nil {
-		ttl = time.Until(*cacheItem.expiry)
-	}
-
-	return string(cacheItem.value), ttl, nil
-}
-
-func exractItem(el list.Element) (*cacheItem, error) {
-	cacheItem, ok := el.Value.(*cacheItem)
-	if !ok {
-		return nil, anycache.ErrKeyNotExists
-	}
-
-	if cacheItem.expiry == nil {
-		return cacheItem, nil
-	}
-
-	ttl := time.Until(*cacheItem.expiry)
-
+	ttl := time.Until(*item.expiry)
 	if ttl <= 0 {
-		return nil, anycache.ErrKeyNotExists
+		s.delete(item)
+
+		return "", 0, anycache.ErrKeyNotExists
 	}
 
-	return cacheItem, nil
+	return string(item.value), ttl, nil
 }
 
 func Close() error {

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -146,6 +146,7 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 func (s *Storage) delete(item *cacheItem) {
 	delete(s.index, item.key)
 	s.items.Remove(item.lruPos)
+
 	if item.expiryPos >= 0 {
 		heap.Remove(&s.expiryQ, item.expiryPos)
 	}
@@ -185,17 +186,15 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 func (s *Storage) expiryLoop() {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
 			s.mu.Lock()
-			if s.expiryQ.Len() == 0 {
-				continue
-			}
 
-			for {
+			for s.expiryQ.Len() > 0 {
 				item := s.expiryQ[0]
 				if time.Until(*item.expiry) > 0 {
 					break

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -145,7 +145,9 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 func (s *Storage) delete(item *cacheItem) {
 	delete(s.index, item.key)
 	s.items.Remove(item.lruPos)
-	heap.Remove(&s.expiryQ, item.expiryPos)
+	if item.expiryPos >= 0 {
+		heap.Remove(&s.expiryQ, item.expiryPos)
+	}
 }
 
 func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -11,14 +11,14 @@ import (
 )
 
 type cacheItem struct {
-	value  []byte
 	expiry *time.Time
+	value  []byte
 }
 
 type InMemoryCacheStorage struct {
-	limit uint
 	index map[string]*list.Element
 	items *list.List
+	limit uint
 	mu    sync.RWMutex
 }
 
@@ -41,6 +41,10 @@ func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error
 }
 
 func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, ttl time.Duration) error {
+	if ttl < 0 {
+		return errors.New("ttl must be non-negative")
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -52,8 +56,8 @@ func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, 
 	}
 
 	storageItem := &cacheItem{
-		[]byte(value),
-		expiry,
+		value:  []byte(value),
+		expiry: expiry,
 	}
 
 	elem := &list.Element{
@@ -89,11 +93,17 @@ func (s *InMemoryCacheStorage) Del(_ context.Context, key string) (bool, error) 
 		return false, nil
 	}
 
+	_, err := exractItem(*elem)
+
 	delete(s.index, key)
 
 	s.items.Remove(elem)
 
-	return false, nil
+	if errors.Is(err, anycache.ErrKeyNotExists) {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (s *InMemoryCacheStorage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
@@ -106,22 +116,43 @@ func (s *InMemoryCacheStorage) GetWithTTL(_ context.Context, key string) (string
 		return "", 0, anycache.ErrKeyNotExists
 	}
 
-	cacheItem, ok := item.Value.(*cacheItem)
+	cacheItem, err := exractItem(*item)
+
+	switch {
+	case errors.Is(err, anycache.ErrKeyNotExists):
+		delete(s.index, key)
+		s.items.Remove(item)
+
+		return "", 0, err
+	case err != nil:
+		return "", 0, err
+	}
+
+	var ttl time.Duration
+	if cacheItem.expiry != nil {
+		ttl = time.Until(*cacheItem.expiry)
+	}
+
+	return string(cacheItem.value), ttl, nil
+}
+
+func exractItem(el list.Element) (*cacheItem, error) {
+	cacheItem, ok := el.Value.(*cacheItem)
 	if !ok {
-		return "", 0, anycache.ErrKeyNotExists
+		return nil, anycache.ErrKeyNotExists
 	}
 
 	if cacheItem.expiry == nil {
-		return string(cacheItem.value), 0, nil
+		return cacheItem, nil
 	}
 
 	ttl := time.Until(*cacheItem.expiry)
 
 	if ttl <= 0 {
-		return "", 0, anycache.ErrKeyNotExists
+		return nil, anycache.ErrKeyNotExists
 	}
 
-	return "", ttl, nil
+	return cacheItem, nil
 }
 
 func Close() error {

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -1,0 +1,44 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+)
+
+// type CacheStorage interface {
+// 	Get(context.Context, string) (string, error)
+// 	Set(context.Context, string, string, time.Duration) error
+// 	TTL(context.Context, string) (bool, time.Duration, error)
+// 	Del(context.Context, string) (bool, error)
+// 	GetWithTTL(context.Context, string) (string, time.Duration, error)
+// }
+
+type InMemoryCacheStorage struct{}
+
+func New() *InMemoryCacheStorage {
+	return &InMemoryCacheStorage{}
+}
+
+func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error) {
+	return "", nil
+}
+
+func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, ttl time.Duration) error {
+	return nil
+}
+
+func TTL(_ context.Context, key string) (bool, time.Duration, error) {
+	return false, 0, nil
+}
+
+func Del(_ context.Context, key string) (bool, error) {
+	return false, nil
+}
+
+func GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
+	return "", 0, nil
+}
+
+func Close() error {
+	return nil
+}

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -184,7 +184,7 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 
 func (s *Storage) expiryLoop() {
 	ticker := time.NewTicker(time.Second)
-
+	defer ticker.Stop()
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -165,6 +165,7 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 	}
 
 	if item.expiry == nil {
+		s.items.MoveToBack(item.lruPos)
 		return string(item.value), 0, nil
 	}
 

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -134,6 +134,7 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 	}
 
 	if item.expiry != nil && time.Until(*item.expiry) <= 0 {
+		s.delete(item)
 		return false, nil
 	}
 

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/ksysoev/anycache"
 )
 
 type cacheItem struct {
@@ -13,22 +15,28 @@ type cacheItem struct {
 }
 
 type InMemoryCacheStorage struct {
-	index *sync.Map
+	index map[string]*list.Element
 	items *list.List
+	mu    sync.RWMutex
 }
 
 func New() *InMemoryCacheStorage {
 	return &InMemoryCacheStorage{
-		index: &sync.Map{},
+		index: map[string]*list.Element{},
 		items: list.New(),
 	}
 }
 
 func (s *InMemoryCacheStorage) Get(_ context.Context, key string) (string, error) {
-	return "", nil
+	value, _, err := s.GetWithTTL(context.Background(), key)
+
+	return value, err
 }
 
 func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, ttl time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	var expiry *time.Time
 
 	if ttl > 0 {
@@ -41,22 +49,72 @@ func (s *InMemoryCacheStorage) Set(_ context.Context, key string, value string, 
 		expiry,
 	}
 
-	s.index.Store(key, storageItem)
-	s.items.PushBack(storageItem)
+	elem := &list.Element{
+		Value: storageItem,
+	}
+
+	s.index[key] = elem
+	s.items.PushBack(elem)
 
 	return nil
 }
 
-func TTL(_ context.Context, key string) (bool, time.Duration, error) {
-	return false, 0, nil
+func (s *InMemoryCacheStorage) TTL(_ context.Context, key string) (bool, time.Duration, error) {
+	_, ttl, err := s.GetWithTTL(context.Background(), key)
+	if err != nil {
+		return false, 0, err
+	}
+
+	if ttl == 0 {
+		return false, 0, err
+	}
+
+	return true, ttl, nil
 }
 
-func Del(_ context.Context, key string) (bool, error) {
+func (s *InMemoryCacheStorage) Del(_ context.Context, key string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	elem, ok := s.index[key]
+
+	if !ok {
+		return false, nil
+	}
+
+	delete(s.index, key)
+
+	s.items.Remove(elem)
+
 	return false, nil
 }
 
-func GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
-	return "", 0, nil
+func (s *InMemoryCacheStorage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	item, ok := s.index[key]
+
+	if !ok {
+		return "", 0, anycache.ErrKeyNotExists
+	}
+
+	cacheItem, ok := item.Value.(*cacheItem)
+	if !ok {
+		return "", 0, anycache.ErrKeyNotExists
+	}
+
+	if cacheItem.expiry == nil {
+		return string(cacheItem.value), 0, nil
+	}
+
+	ttl := time.Until(*cacheItem.expiry)
+
+	if ttl <= 0 {
+		return "", 0, anycache.ErrKeyNotExists
+	}
+
+	return "", ttl, nil
 }
 
 func Close() error {

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -57,6 +57,8 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 		{
 			name: "Successfully retrieve a value for an existing key",
 			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
 				s, err := New(10)
 				if err != nil {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
@@ -73,6 +75,8 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 		{
 			name: "Fail to retrieve a value for a non-existing key",
 			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
 				s, err := New(10)
 				if err != nil {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
@@ -87,6 +91,8 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 		{
 			name: "Fail to retrieve a value for an expired key",
 			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
 				s, err := New(10)
 				if err != nil {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
@@ -95,6 +101,7 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 				s.Set(t.Context(), "key2", "value2", time.Microsecond)
 
 				time.Sleep(2 * time.Millisecond)
+
 				return s
 			},
 			key:     "key2",
@@ -105,19 +112,408 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
+
 			got, gotErr := s.Get(context.Background(), tt.key)
 			if gotErr != nil {
 				if !tt.wantErr {
 					t.Errorf("Get() failed: %v", gotErr)
 				}
+
 				return
 			}
+
 			if tt.wantErr {
 				t.Fatal("Get() succeeded unexpectedly")
 			}
 
 			if tt.want != got {
 				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInMemoryCacheStorage_Set(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		value         string
+		ttl           time.Duration
+		waitBeforeGet time.Duration
+		wantErr       bool
+		ableToGet     bool
+	}{
+		{
+			name:          "Successfully set a value for a key with no TTL",
+			key:           "key1",
+			value:         "value1",
+			wantErr:       false,
+			waitBeforeGet: 0,
+			ableToGet:     true,
+		},
+		{
+			name:          "Successfully set a value for a key with a TTL and retrieve it before expiration",
+			key:           "key2",
+			value:         "value2",
+			ttl:           2 * time.Millisecond,
+			wantErr:       false,
+			waitBeforeGet: time.Millisecond,
+			ableToGet:     true,
+		},
+		{
+			name:          "Successfully set a value for a key with a TTL and fail to retrieve it after expiration",
+			key:           "key3",
+			value:         "value3",
+			ttl:           time.Millisecond,
+			wantErr:       false,
+			waitBeforeGet: 2 * time.Millisecond,
+			ableToGet:     false,
+		},
+		{
+			name:          "Error when setting a value for a key with an invalid TTL",
+			key:           "key4",
+			value:         "value4",
+			ttl:           -time.Second,
+			wantErr:       true,
+			waitBeforeGet: 0,
+			ableToGet:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := New(10)
+			if err != nil {
+				t.Fatalf("could not construct receiver type: %v", err)
+			}
+
+			gotErr := s.Set(t.Context(), tt.key, tt.value, tt.ttl)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("Set() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("Set() succeeded unexpectedly")
+			}
+
+			if tt.waitBeforeGet > 0 {
+				time.Sleep(tt.waitBeforeGet)
+			}
+
+			value, err := s.Get(t.Context(), tt.key)
+
+			if tt.ableToGet && tt.value != value {
+				t.Errorf("Get() = %v, want %v, err %v", value, tt.value, err)
+			} else if !tt.ableToGet && err == nil {
+				t.Fatal("Get() succeeded unexpectedly")
+			}
+		})
+	}
+}
+
+func TestInMemoryCacheStorage_TTL(t *testing.T) {
+	tests := []struct {
+		setup   func(*testing.T) *InMemoryCacheStorage
+		name    string
+		key     string
+		want2   time.Duration
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Successfully retrieve TTL for an existing key with no expiration",
+			key:  "key1",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err = s.Set(t.Context(), "key1", "value1", 0); err != nil {
+					t.Fatalf("Failed to set key1: %v", err)
+				}
+
+				return s
+			},
+			want:    false,
+			want2:   0,
+			wantErr: false,
+		},
+		{
+			name: "Successfully retrieve TTL for an existing key with expiration",
+			key:  "key2",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err = s.Set(t.Context(), "key2", "value2", time.Millisecond); err != nil {
+					t.Fatalf("Failed to set key2: %v", err)
+				}
+
+				return s
+			},
+			want:    true,
+			want2:   time.Millisecond,
+			wantErr: false,
+		},
+		{
+			name: "Fail to retrieve TTL for a non-existing key",
+			key:  "nonExistingKey",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err = s.Set(t.Context(), "key3", "value3", time.Millisecond); err != nil {
+					t.Fatalf("Failed to set key3: %v", err)
+				}
+
+				return s
+			},
+
+			want:    false,
+			want2:   0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup(t)
+
+			got, got2, gotErr := s.TTL(context.Background(), tt.key)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("TTL() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("TTL() succeeded unexpectedly")
+			}
+
+			if got != tt.want {
+				t.Errorf("TTL() got = %v, want %v", got, tt.want)
+			}
+
+			if tt.want2 > 0 && got2 > 0 && tt.want2 < got2 {
+				t.Errorf("TTL() got2 = %v, want approximately %v", got2, tt.want2)
+			} else if tt.want2 > 0 && got2 <= 0 {
+				t.Errorf("TTL() got2 = %v, want approximately %v", got2, tt.want2)
+			} else if tt.want2 == 0 && got2 != 0 {
+				t.Errorf("TTL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestInMemoryCacheStorage_Del(t *testing.T) {
+	tests := []struct {
+		setup   func(*testing.T) *InMemoryCacheStorage
+		name    string
+		key     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Successfully delete an existing key",
+			key:  "key1",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err := s.Set(t.Context(), "key1", "value1", 0); err != nil {
+					t.Fatalf("Failed to set key1: %v", err)
+				}
+
+				return s
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Fail to delete a non-existing key",
+			key:  "key2",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err := s.Set(t.Context(), "key1", "value1", 0); err != nil {
+					t.Fatalf("Failed to set key1: %v", err)
+				}
+
+				return s
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Remove expired key",
+			key:  "key3",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err := s.Set(t.Context(), "key3", "value3", time.Millisecond); err != nil {
+					t.Fatalf("Failed to set key3: %v", err)
+				}
+
+				time.Sleep(2 * time.Millisecond)
+
+				return s
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup(t)
+
+			got, gotErr := s.Del(context.Background(), tt.key)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("Del() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("Del() succeeded unexpectedly")
+			}
+
+			if tt.want != got {
+				t.Errorf("Del() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
+	tests := []struct {
+		name    string // description of this test case
+		setup   func(*testing.T) *InMemoryCacheStorage
+		key     string
+		want    string
+		want2   time.Duration
+		wantErr bool
+	}{
+		{
+			name: "Successfully retrieve a value and TTL for an existing key",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err = s.Set(t.Context(), "key1", "value1", time.Millisecond); err != nil {
+					t.Fatalf("Failed to set key1: %v", err)
+				}
+
+				return s
+			},
+			key:     "key1",
+			want:    "value1",
+			want2:   time.Millisecond,
+			wantErr: false,
+		},
+		{
+			name: "Fail to retrieve a value and TTL for a non-existing key",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err = s.Set(t.Context(), "key1", "value1", time.Millisecond); err != nil {
+					t.Fatalf("Failed to set key1: %v", err)
+				}
+
+				return s
+			},
+			key:     "nonExistingKey",
+			want:    "",
+			want2:   0,
+			wantErr: true,
+		},
+		{
+			name: "Fail to retrieve a value and TTL for an expired key",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				t.Helper()
+
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				if err = s.Set(t.Context(), "key2", "value2", time.Millisecond); err != nil {
+					t.Fatalf("Failed to set key2: %v", err)
+				}
+
+				time.Sleep(2 * time.Millisecond)
+
+				return s
+			},
+			key: "key2", want: "",
+			want2:   0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup(t)
+
+			got, got2, gotErr := s.GetWithTTL(context.Background(), tt.key)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("GetWithTTL() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("GetWithTTL() succeeded unexpectedly")
+			}
+
+			if tt.want != got {
+				t.Errorf("GetWithTTL() = %v, want %v", got, tt.want)
+			}
+
+			if tt.want2 > 0 && got2 > 0 && tt.want2 < got2 {
+				t.Errorf("GetWithTTL() = %v, want %v", got2, tt.want2)
+			}
+
+			if tt.want2 > 0 && got2 <= 0 {
+				t.Errorf("GetWithTTL() = %v, want %v", got2, tt.want2)
 			}
 		})
 	}

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -49,14 +49,14 @@ func TestNew(t *testing.T) {
 func TestInMemoryCacheStorage_Get(t *testing.T) {
 	tests := []struct {
 		name    string // description of this test case
-		setup   func(*testing.T) *InMemoryCacheStorage
+		setup   func(*testing.T) *Storage
 		key     string
 		want    string
 		wantErr bool
 	}{
 		{
 			name: "Successfully retrieve a value for an existing key",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -64,7 +64,9 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				s.Set(t.Context(), "key1", "value1", 0)
+				if err := s.Set(t.Context(), "key1", "value1", 0); err != nil {
+					t.Fatalf("Failed to set key1: %v", err)
+				}
 
 				return s
 			},
@@ -74,7 +76,7 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 		},
 		{
 			name: "Fail to retrieve a value for a non-existing key",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -90,7 +92,7 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 		},
 		{
 			name: "Fail to retrieve a value for an expired key",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -98,7 +100,9 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				s.Set(t.Context(), "key2", "value2", time.Microsecond)
+				if err := s.Set(t.Context(), "key2", "value2", time.Microsecond); err != nil {
+					t.Fatalf("Failed to set key2: %v", err)
+				}
 
 				time.Sleep(2 * time.Millisecond)
 
@@ -216,7 +220,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 
 func TestInMemoryCacheStorage_TTL(t *testing.T) {
 	tests := []struct {
-		setup   func(*testing.T) *InMemoryCacheStorage
+		setup   func(*testing.T) *Storage
 		name    string
 		key     string
 		want2   time.Duration
@@ -226,7 +230,7 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 		{
 			name: "Successfully retrieve TTL for an existing key with no expiration",
 			key:  "key1",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -247,7 +251,9 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 		{
 			name: "Successfully retrieve TTL for an existing key with expiration",
 			key:  "key2",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
+				t.Helper()
+
 				s, err := New(10)
 				if err != nil {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
@@ -266,7 +272,7 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 		{
 			name: "Fail to retrieve TTL for a non-existing key",
 			key:  "nonExistingKey",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -307,11 +313,12 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 				t.Errorf("TTL() got = %v, want %v", got, tt.want)
 			}
 
-			if tt.want2 > 0 && got2 > 0 && tt.want2 < got2 {
+			switch {
+			case tt.want2 > 0 && got2 > 0 && tt.want2 < got2:
 				t.Errorf("TTL() got2 = %v, want approximately %v", got2, tt.want2)
-			} else if tt.want2 > 0 && got2 <= 0 {
+			case tt.want2 > 0 && got2 <= 0:
 				t.Errorf("TTL() got2 = %v, want approximately %v", got2, tt.want2)
-			} else if tt.want2 == 0 && got2 != 0 {
+			case tt.want2 == 0 && got2 != 0:
 				t.Errorf("TTL() got2 = %v, want %v", got2, tt.want2)
 			}
 		})
@@ -320,7 +327,7 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 
 func TestInMemoryCacheStorage_Del(t *testing.T) {
 	tests := []struct {
-		setup   func(*testing.T) *InMemoryCacheStorage
+		setup   func(*testing.T) *Storage
 		name    string
 		key     string
 		want    bool
@@ -329,7 +336,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 		{
 			name: "Successfully delete an existing key",
 			key:  "key1",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -349,7 +356,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 		{
 			name: "Fail to delete a non-existing key",
 			key:  "key2",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -369,7 +376,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 		{
 			name: "Remove expired key",
 			key:  "key3",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -416,7 +423,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 	tests := []struct {
 		name    string // description of this test case
-		setup   func(*testing.T) *InMemoryCacheStorage
+		setup   func(*testing.T) *Storage
 		key     string
 		want    string
 		want2   time.Duration
@@ -424,7 +431,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 	}{
 		{
 			name: "Successfully retrieve a value and TTL for an existing key",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -445,7 +452,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 		},
 		{
 			name: "Fail to retrieve a value and TTL for a non-existing key",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)
@@ -466,7 +473,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 		},
 		{
 			name: "Fail to retrieve a value and TTL for an expired key",
-			setup: func(t *testing.T) *InMemoryCacheStorage {
+			setup: func(t *testing.T) *Storage {
 				t.Helper()
 
 				s, err := New(10)

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -35,6 +35,8 @@ func TestNew(t *testing.T) {
 				return
 			}
 
+			defer func() { _ = got.Close() }()
+
 			if tt.wantErr {
 				t.Fatal("New() succeeded unexpectedly")
 			}
@@ -117,6 +119,8 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
 
+			defer func() { _ = s.Close() }()
+
 			got, gotErr := s.Get(context.Background(), tt.key)
 			if gotErr != nil {
 				if !tt.wantErr {
@@ -189,6 +193,8 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 			if err != nil {
 				t.Fatalf("could not construct receiver type: %v", err)
 			}
+
+			defer func() { _ = s.Close() }()
 
 			gotErr := s.Set(t.Context(), tt.key, tt.value, tt.ttl)
 			if gotErr != nil {
@@ -296,6 +302,8 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
 
+			defer func() { _ = s.Close() }()
+
 			got, got2, gotErr := s.TTL(context.Background(), tt.key)
 			if gotErr != nil {
 				if !tt.wantErr {
@@ -400,6 +408,8 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
 
+			defer func() { _ = s.Close() }()
+
 			got, gotErr := s.Del(context.Background(), tt.key)
 			if gotErr != nil {
 				if !tt.wantErr {
@@ -498,6 +508,8 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.setup(t)
 
+			defer func() { _ = s.Close() }()
+
 			got, got2, gotErr := s.GetWithTTL(context.Background(), tt.key)
 			if gotErr != nil {
 				if !tt.wantErr {
@@ -523,5 +535,42 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 				t.Errorf("GetWithTTL() = %v, want %v", got2, tt.want2)
 			}
 		})
+	}
+}
+
+func TestInMemoryCacheStorage_Close(t *testing.T) {
+	s, err := New(10)
+	if err != nil {
+		t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+	}
+
+	err = s.Set(t.Context(), "key1", "value1", 0)
+	if err != nil {
+		t.Fatalf("Failed to set key1: %v", err)
+	}
+
+	_, err = s.Get(t.Context(), "key1")
+	if err != nil {
+		t.Fatalf("Failed to get key1: %v", err)
+	}
+
+	err = s.Close()
+	if err != nil {
+		t.Fatalf("Failed to close InMemoryCacheStorage: %v", err)
+	}
+
+	err = s.Set(t.Context(), "key2", "value2", 0)
+	if err == nil {
+		t.Fatal("Set() succeeded unexpectedly after Close()")
+	}
+
+	_, err = s.Get(t.Context(), "key1")
+	if err == nil {
+		t.Fatal("Get() succeeded unexpectedly after Close()")
+	}
+
+	err = s.Close()
+	if err == nil {
+		t.Fatal("Close() succeeded unexpectedly on already closed storage")
 	}
 }

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -10,7 +10,7 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
 		// Named input parameters for target function.
-		limit   uint
+		limit   int
 		wantErr bool
 	}{
 		{

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -1,0 +1,124 @@
+package inmemory
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		limit   uint
+		wantErr bool
+	}{
+		{
+			name:    "Successfully create a new InMemoryCacheStorage with a valid limit",
+			limit:   10,
+			wantErr: false,
+		},
+		{
+			name:    "Fail to create a new InMemoryCacheStorage with a limit of 0",
+			limit:   0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := New(tt.limit)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("New() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("New() succeeded unexpectedly")
+			}
+
+			if got == nil {
+				t.Fatal("New() returned nil unexpectedly")
+			}
+		})
+	}
+}
+
+func TestInMemoryCacheStorage_Get(t *testing.T) {
+	tests := []struct {
+		name    string // description of this test case
+		setup   func(*testing.T) *InMemoryCacheStorage
+		key     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Successfully retrieve a value for an existing key",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				s.Set(t.Context(), "key1", "value1", 0)
+
+				return s
+			},
+			key:     "key1",
+			want:    "value1",
+			wantErr: false,
+		},
+		{
+			name: "Fail to retrieve a value for a non-existing key",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				return s
+			},
+			key:     "nonExistingKey",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Fail to retrieve a value for an expired key",
+			setup: func(t *testing.T) *InMemoryCacheStorage {
+				s, err := New(10)
+				if err != nil {
+					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
+				}
+
+				s.Set(t.Context(), "key2", "value2", time.Microsecond)
+
+				time.Sleep(2 * time.Millisecond)
+				return s
+			},
+			key:     "key2",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.setup(t)
+			got, gotErr := s.Get(context.Background(), tt.key)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("Get() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("Get() succeeded unexpectedly")
+			}
+
+			if tt.want != got {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new in-memory cache storage implementation with support for item expiration and LRU (Least Recently Used) eviction. The main logic is divided between two new files: `inmemory.go`, which implements the storage logic, and `expiryq.go`, which provides a heap-based expiry queue for efficient expiration management.

Key additions and their purposes:

**In-memory cache storage implementation:**

* Added a new `Storage` struct in `inmemory.go` that manages cache items, supports LRU eviction, and handles TTL (time-to-live) expiration using a background goroutine.
* Implemented core cache operations: `Get`, `Set`, `Del`, `TTL`, and `Close`, all with thread safety and proper error handling.
* Introduced a background `expiryLoop` that periodically removes expired items from the cache.

**Expiry queue for TTL management:**

* Added `expiryQueue` in `expiryq.go`, a min-heap structure to efficiently track and remove items as they expire, with methods to maintain heap invariants and update item positions.
* Integrated the expiry queue into the main storage logic to ensure expired items are evicted promptly and efficiently. [[1]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925R1-R228) [[2]](diffhunk://#diff-ee79d2f256f873c684f4eb4f8cdda33926291ef80653c732d7222a031401e78bR1-R36)

These changes lay the foundation for a robust, concurrent in-memory cache with both LRU and TTL-based eviction policies.