### PR TITLE
Change storage interface to bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
         Addr: "localhost:6379",
     })
 
-    redisStorage := redisstor.New(redisClient)
+    redisStorage := redisstore.New(redisClient)
 
     // Creates anycache with 10% TTL randomization
     cache := anycache.New(redisStorage, anycache.WithTTLRandomization(10))

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Here's an example of how to use anycache to cache the result of a function that 
 package main
 
 import (
+    "context"
     "fmt"
     "math/rand"
     "time"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
     redisStorage := redisstor.New(redisClient)
 
     // Creates anycache with 10% TTL randomization
-    cache := anycache.New(redisStorage, WithTTLRandomization(10))
+    cache := anycache.New(redisStorage, anycache.WithTTLRandomization(10))
     defer cache.Close()
 
     generator := func() (string, error) {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import (
 
     "github.com/redis/go-redis/v9"
     "github.com/ksysoev/anycache"
-    "github.com/ksysoev/anycache/storage/redis"
+    redisstore "github.com/ksysoev/anycache/storage/redis"
 )
 
 func main() {
@@ -43,10 +43,10 @@ func main() {
         Addr: "localhost:6379",
     })
 
-    redisStorage := redisstor.NewRedisCacheStorage(redisClient)
+    redisStorage := redisstor.New(redisClient)
 
     // Creates anycache with 10% TTL randomization
-    cache := anycache.NewCache(redisStorage, WithTTLRandomization(10))
+    cache := anycache.New(redisStorage, WithTTLRandomization(10))
     defer cache.Close()
 
     generator := func() (string, error) {
@@ -54,7 +54,7 @@ func main() {
         return fmt.Sprintf("%d", randomNumber), nil
     }
 
-    value, err := cache.Cache(
+    value, err := cache.CacheS(
         "random_number_key", 
         generator, 
         WithTTL(5 * time.Minute), 

--- a/anycache.go
+++ b/anycache.go
@@ -101,7 +101,7 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 // The function takes an optional list of CacheItemOptions to customize the caching behavior.
 // WithTTL sets TTL for cache item
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
-func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator, opts ...CacheItemOptions) (string, error) {
+func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator, opts ...CacheItemOptions) ([]byte, error) {
 	var req CacheReuest
 
 	for _, opt := range opts {
@@ -156,18 +156,18 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 
 	select {
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return nil, ctx.Err()
 	case resp := <-res:
 		if resp.Err != nil {
-			return "", resp.Err
+			return nil, resp.Err
 		}
 
 		val, ok := resp.Val.([]byte)
 		if !ok {
-			return "", errors.New("unexpected value type returned from generator")
+			return nil, errors.New("unexpected value type returned from generator")
 		}
 
-		return string(val), nil
+		return val, nil
 	}
 }
 
@@ -199,7 +199,7 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 		return err
 	}
 
-	err = json.Unmarshal([]byte(val), result)
+	err = json.Unmarshal(val, result)
 
 	return err
 }

--- a/anycache.go
+++ b/anycache.go
@@ -162,12 +162,12 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 			return "", resp.Err
 		}
 
-		val, ok := resp.Val.(string)
+		val, ok := resp.Val.([]byte)
 		if !ok {
 			return "", errors.New("unexpected value type returned from generator")
 		}
 
-		return val, nil
+		return string(val), nil
 	}
 }
 

--- a/anycache.go
+++ b/anycache.go
@@ -22,11 +22,11 @@ var ErrKeyNotExists = errors.New("key does not exist")
 
 // CacheStorage
 type CacheStorage interface {
-	Get(context.Context, string) (string, error)
-	Set(context.Context, string, string, time.Duration) error
+	Get(context.Context, string) ([]byte, error)
+	Set(context.Context, string, []byte, time.Duration) error
 	TTL(context.Context, string) (bool, time.Duration, error)
 	Del(context.Context, string) (bool, error)
-	GetWithTTL(context.Context, string) (string, time.Duration, error)
+	GetWithTTL(context.Context, string) ([]byte, time.Duration, error)
 }
 
 // Cache
@@ -47,7 +47,7 @@ type CacheReuest struct {
 }
 
 type (
-	CacheGenerator func(ctx context.Context) (string, error)
+	CacheGenerator func(ctx context.Context) ([]byte, error)
 	CacheOptions   func(*Cache)
 )
 
@@ -180,18 +180,18 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
 // Returns an error if there was a problem caching or unmarshalling the value.
 func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {
-	generatorWrapper := func(ctx context.Context) (string, error) {
+	generatorWrapper := func(ctx context.Context) ([]byte, error) {
 		val, err := generator(ctx)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		jsonVal, err := json.Marshal(val)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
-		return string(jsonVal), nil
+		return jsonVal, nil
 	}
 
 	val, err := c.Cache(ctx, key, generatorWrapper, opts...)
@@ -219,7 +219,7 @@ func (c *Cache) Invalidate(ctx context.Context, key string) error {
 // generateAndSet generates a value using the provided generator function,
 // sets it in the cache storage with the given key and options,
 // and returns the generated value and any error encountered.
-func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator CacheGenerator) (string, error) {
+func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator CacheGenerator) ([]byte, error) {
 	value, err := generator(ctx)
 	if err != nil {
 		return value, err

--- a/anycache.go
+++ b/anycache.go
@@ -47,16 +47,17 @@ type CacheReuest struct {
 }
 
 type (
-	CacheGenerator func(ctx context.Context) ([]byte, error)
-	CacheOptions   func(*Cache)
+	CacheGenerator  func(ctx context.Context) ([]byte, error)
+	CacheGeneratorS func(ctx context.Context) (string, error)
+	CacheOptions    func(*Cache)
 )
 
 type CacheItemOptions func(*CacheReuest)
 
-// NewCache creates a new Cache instance with the provided CacheStorage and CacheOptions.
+// New creates a new Cache instance with the provided CacheStorage and CacheOptions.
 // WithTTLRandomization sets max shift of TTL in persent
 // It returns the created Cache instance.
-func NewCache(store CacheStorage, opts ...CacheOptions) *Cache {
+func New(store CacheStorage, opts ...CacheOptions) *Cache {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	c := Cache{
@@ -169,6 +170,25 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 
 		return val, nil
 	}
+}
+
+// CacheS is a convenience method that wraps the Cache method to return a string value instead of a byte slice.
+func (c *Cache) CacheS(ctx context.Context, key string, generator CacheGeneratorS, opts ...CacheItemOptions) (string, error) {
+	generatorWrapper := func(ctx context.Context) ([]byte, error) {
+		result, err := generator(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return []byte(result), nil
+	}
+
+	val, err := c.Cache(ctx, key, generatorWrapper, opts...)
+	if err != nil {
+		return "", err
+	}
+
+	return string(val), nil
 }
 
 // CacheStruct caches the result of a function that returns a struct.

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -21,7 +21,7 @@ func TestCache(t *testing.T) {
 	cache := NewCache(store)
 
 	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return(nil, ErrKeyNotExists).Once()
-	store.EXPECT().Set(mock.Anything, "TestCacheKey", "testValue", mock.Anything).Return(nil)
+	store.EXPECT().Set(mock.Anything, "TestCacheKey", []byte("testValue"), mock.Anything).Return(nil)
 
 	val, err := cache.Cache(t.Context(), "TestCacheKey", getGenerator([]byte("testValue"), nil))
 	if err != nil {
@@ -85,7 +85,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	cache := NewCache(store)
 
 	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
-	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", "newTestValue", 2*time.Second).Return(nil)
+	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", []byte("newTestValue"), 2*time.Second).Return(nil)
 
 	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", getGenerator([]byte("newTestValue"), nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
 	if err != nil {
@@ -111,7 +111,7 @@ func TestCacheJSON(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
 	store.EXPECT().Get(mock.Anything, "TestCacheJSONKey").Return(nil, ErrKeyNotExists)
-	store.EXPECT().Set(mock.Anything, "TestCacheJSONKey", "{\"foo\":\"bar\"}", mock.Anything).Return(nil)
+	store.EXPECT().Set(mock.Anything, "TestCacheJSONKey", []byte("{\"foo\":\"bar\"}"), mock.Anything).Return(nil)
 	// Define a test key and value
 	key := "TestCacheJSONKey"
 	value := map[string]string{
@@ -143,8 +143,7 @@ func TestCancelingRequest(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
 	store.EXPECT().Get(mock.Anything, "TestCancelingRequestKey").Return(nil, ErrKeyNotExists)
-	store.EXPECT().Set(mock.Anything, "TestCancelingRequestKey", "testValue", mock.Anything).Return(nil)
-
+	store.EXPECT().Set(mock.Anything, "TestCancelingRequestKey", []byte("testValue"), mock.Anything).Return(nil)
 	// Define a generator function that returns the test value
 	generator := func(ctx context.Context) ([]byte, error) {
 		<-ctx.Done()

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func getGenerator(val string, err error) CacheGenerator {
-	return func(_ context.Context) (string, error) {
+func getGenerator(val []byte, err error) CacheGenerator {
+	return func(_ context.Context) ([]byte, error) {
 		return val, err
 	}
 }
@@ -20,10 +20,10 @@ func TestCache(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
 
-	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return("TestCacheKey", ErrKeyNotExists).Once()
+	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return(nil, ErrKeyNotExists).Once()
 	store.EXPECT().Set(mock.Anything, "TestCacheKey", "testValue", mock.Anything).Return(nil)
 
-	val, err := cache.Cache(t.Context(), "TestCacheKey", getGenerator("testValue", nil))
+	val, err := cache.Cache(t.Context(), "TestCacheKey", getGenerator([]byte("testValue"), nil))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -32,9 +32,9 @@ func TestCache(t *testing.T) {
 		t.Errorf("Expected to get testValue, but got '%v'", val)
 	}
 
-	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return("testValue", nil)
+	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return([]byte("testValue"), nil)
 
-	val, err = cache.Cache(t.Context(), "TestCacheKey", getGenerator("testValue1", nil))
+	val, err = cache.Cache(t.Context(), "TestCacheKey", getGenerator([]byte("testValue1"), nil))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -50,21 +50,21 @@ func TestCacheConcurrency(t *testing.T) {
 
 	results := make(chan string)
 
-	store.EXPECT().Get(mock.Anything, "TestCacheConcurrencyKey").Return("", ErrKeyNotExists)
+	store.EXPECT().Get(mock.Anything, "TestCacheConcurrencyKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCacheConcurrencyKey", mock.Anything, mock.Anything).Return(nil)
 
 	go func(c *Cache, ch chan string) {
-		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
+		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) ([]byte, error) {
 			time.Sleep(time.Millisecond)
-			return "testValue", nil
+			return []byte("testValue"), nil
 		})
 		ch <- val
 	}(cache, results)
 
 	go func(c *Cache, ch chan string) {
-		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) (string, error) {
+		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) ([]byte, error) {
 			time.Sleep(time.Millisecond)
-			return "testValue1", nil
+			return []byte("testValue1"), nil
 		})
 		ch <- val
 	}(cache, results)
@@ -84,10 +84,10 @@ func TestCacheWarmingUp(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
 
-	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return("testValue", 500*time.Millisecond, nil)
+	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
 	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", "newTestValue", 2*time.Second).Return(nil)
 
-	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", getGenerator("newTestValue", nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
+	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", getGenerator([]byte("newTestValue"), nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -110,7 +110,7 @@ func TestRandomizeTTL(t *testing.T) {
 func TestCacheJSON(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
-	store.EXPECT().Get(mock.Anything, "TestCacheJSONKey").Return("", ErrKeyNotExists)
+	store.EXPECT().Get(mock.Anything, "TestCacheJSONKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCacheJSONKey", "{\"foo\":\"bar\"}", mock.Anything).Return(nil)
 	// Define a test key and value
 	key := "TestCacheJSONKey"
@@ -142,13 +142,13 @@ func TestCacheJSON(t *testing.T) {
 func TestCancelingRequest(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
-	store.EXPECT().Get(mock.Anything, "TestCancelingRequestKey").Return("", ErrKeyNotExists)
+	store.EXPECT().Get(mock.Anything, "TestCancelingRequestKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCancelingRequestKey", "testValue", mock.Anything).Return(nil)
 
 	// Define a generator function that returns the test value
-	generator := func(ctx context.Context) (string, error) {
+	generator := func(ctx context.Context) ([]byte, error) {
 		<-ctx.Done()
-		return "testValue", nil
+		return []byte("testValue"), nil
 	}
 
 	// Call the CacheJSON function to cache the test value

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -28,9 +28,7 @@ func TestCache(t *testing.T) {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
 
-	if val != "testValue" {
-		t.Errorf("Expected to get testValue, but got '%v'", val)
-	}
+	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
 
 	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return([]byte("testValue"), nil)
 
@@ -39,21 +37,19 @@ func TestCache(t *testing.T) {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
 
-	if val != "testValue" {
-		t.Errorf("Expected to get testValue, but got '%v'", val)
-	}
+	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
 }
 
 func TestCacheConcurrency(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := NewCache(store)
 
-	results := make(chan string)
+	results := make(chan []byte)
 
 	store.EXPECT().Get(mock.Anything, "TestCacheConcurrencyKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCacheConcurrencyKey", mock.Anything, mock.Anything).Return(nil)
 
-	go func(c *Cache, ch chan string) {
+	go func(c *Cache, ch chan []byte) {
 		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) ([]byte, error) {
 			time.Sleep(time.Millisecond)
 			return []byte("testValue"), nil
@@ -61,7 +57,7 @@ func TestCacheConcurrency(t *testing.T) {
 		ch <- val
 	}(cache, results)
 
-	go func(c *Cache, ch chan string) {
+	go func(c *Cache, ch chan []byte) {
 		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) ([]byte, error) {
 			time.Sleep(time.Millisecond)
 			return []byte("testValue1"), nil
@@ -71,13 +67,9 @@ func TestCacheConcurrency(t *testing.T) {
 
 	val1, val2 := <-results, <-results
 
-	if val1 != "testValue" && val1 != "testValue1" {
-		t.Errorf("Expected to get testValue as a result, but got '%v'", val1)
-	}
-
-	if val1 != val2 {
-		t.Errorf("Expected to get same result for concurent requests, but got '%v' and '%v", val1, val2)
-	}
+	assert.Contains(t, [][]byte{[]byte("testValue"), []byte("testValue1")}, val1, "Expected to get testValue or testValue1 as a result, but got '%v'", val1)
+	assert.Contains(t, [][]byte{[]byte("testValue"), []byte("testValue1")}, val2, "Expected to get testValue or testValue1 as a result, but got '%v'", val2)
+	assert.Equal(t, val1, val2, "Expected to get the same value for both calls, but got '%v' and '%v'", val1, val2)
 }
 
 func TestCacheWarmingUp(t *testing.T) {
@@ -92,9 +84,7 @@ func TestCacheWarmingUp(t *testing.T) {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
 
-	if val != "testValue" {
-		t.Errorf("Expected to get testValue, but got '%v'", val)
-	}
+	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
 
 	time.Sleep(time.Millisecond)
 }
@@ -161,9 +151,7 @@ func TestCancelingRequest(t *testing.T) {
 	}
 
 	// Check that the result variable contains the expected value
-	if result != "" {
-		t.Errorf("Cache returned an unexpected value: %v", result)
-	}
+	assert.Nil(t, result, "Expected to get nil result, but got '%v'", result)
 
 	cancel()
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -18,7 +18,7 @@ func getGenerator(val []byte, err error) CacheGenerator {
 
 func TestCache(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	cache := NewCache(store)
+	cache := New(store)
 
 	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return(nil, ErrKeyNotExists).Once()
 	store.EXPECT().Set(mock.Anything, "TestCacheKey", []byte("testValue"), mock.Anything).Return(nil)
@@ -42,7 +42,7 @@ func TestCache(t *testing.T) {
 
 func TestCacheConcurrency(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	cache := NewCache(store)
+	cache := New(store)
 
 	results := make(chan []byte)
 
@@ -74,7 +74,7 @@ func TestCacheConcurrency(t *testing.T) {
 
 func TestCacheWarmingUp(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	cache := NewCache(store)
+	cache := New(store)
 
 	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
 	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", []byte("newTestValue"), 2*time.Second).Return(nil)
@@ -99,7 +99,7 @@ func TestRandomizeTTL(t *testing.T) {
 
 func TestCacheJSON(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	cache := NewCache(store)
+	cache := New(store)
 	store.EXPECT().Get(mock.Anything, "TestCacheJSONKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCacheJSONKey", []byte("{\"foo\":\"bar\"}"), mock.Anything).Return(nil)
 	// Define a test key and value
@@ -131,7 +131,7 @@ func TestCacheJSON(t *testing.T) {
 
 func TestCancelingRequest(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	cache := NewCache(store)
+	cache := New(store)
 	store.EXPECT().Get(mock.Anything, "TestCancelingRequestKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCancelingRequestKey", []byte("testValue"), mock.Anything).Return(nil)
 	// Define a generator function that returns the test value
@@ -206,7 +206,7 @@ func TestCache_Invalidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := tt.setup()
-			c := NewCache(store)
+			c := New(store)
 
 			gotErr := c.Invalidate(t.Context(), tt.key)
 			if gotErr != nil {

--- a/cache_storage_mock.go
+++ b/cache_storage_mock.go
@@ -24,51 +24,6 @@ func (_m *MockCacheStorage) EXPECT() *MockCacheStorage_Expecter {
 	return &MockCacheStorage_Expecter{mock: &_m.Mock}
 }
 
-// Close provides a mock function with no fields
-func (_m *MockCacheStorage) Close() error {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Close")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockCacheStorage_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
-type MockCacheStorage_Close_Call struct {
-	*mock.Call
-}
-
-// Close is a helper method to define mock.On call
-func (_e *MockCacheStorage_Expecter) Close() *MockCacheStorage_Close_Call {
-	return &MockCacheStorage_Close_Call{Call: _e.mock.On("Close")}
-}
-
-func (_c *MockCacheStorage_Close_Call) Run(run func()) *MockCacheStorage_Close_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockCacheStorage_Close_Call) Return(_a0 error) *MockCacheStorage_Close_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockCacheStorage_Close_Call) RunAndReturn(run func() error) *MockCacheStorage_Close_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Del provides a mock function with given fields: _a0, _a1
 func (_m *MockCacheStorage) Del(_a0 context.Context, _a1 string) (bool, error) {
 	ret := _m.Called(_a0, _a1)
@@ -127,22 +82,24 @@ func (_c *MockCacheStorage_Del_Call) RunAndReturn(run func(context.Context, stri
 }
 
 // Get provides a mock function with given fields: _a0, _a1
-func (_m *MockCacheStorage) Get(_a0 context.Context, _a1 string) (string, error) {
+func (_m *MockCacheStorage) Get(_a0 context.Context, _a1 string) ([]byte, error) {
 	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
 	}
 
-	var r0 string
+	var r0 []byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
 		return rf(_a0, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
@@ -173,34 +130,36 @@ func (_c *MockCacheStorage_Get_Call) Run(run func(_a0 context.Context, _a1 strin
 	return _c
 }
 
-func (_c *MockCacheStorage_Get_Call) Return(_a0 string, _a1 error) *MockCacheStorage_Get_Call {
+func (_c *MockCacheStorage_Get_Call) Return(_a0 []byte, _a1 error) *MockCacheStorage_Get_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockCacheStorage_Get_Call) RunAndReturn(run func(context.Context, string) (string, error)) *MockCacheStorage_Get_Call {
+func (_c *MockCacheStorage_Get_Call) RunAndReturn(run func(context.Context, string) ([]byte, error)) *MockCacheStorage_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetWithTTL provides a mock function with given fields: _a0, _a1
-func (_m *MockCacheStorage) GetWithTTL(_a0 context.Context, _a1 string) (string, time.Duration, error) {
+func (_m *MockCacheStorage) GetWithTTL(_a0 context.Context, _a1 string) ([]byte, time.Duration, error) {
 	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetWithTTL")
 	}
 
-	var r0 string
+	var r0 []byte
 	var r1 time.Duration
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, time.Duration, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]byte, time.Duration, error)); ok {
 		return rf(_a0, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) time.Duration); ok {
@@ -237,18 +196,18 @@ func (_c *MockCacheStorage_GetWithTTL_Call) Run(run func(_a0 context.Context, _a
 	return _c
 }
 
-func (_c *MockCacheStorage_GetWithTTL_Call) Return(_a0 string, _a1 time.Duration, _a2 error) *MockCacheStorage_GetWithTTL_Call {
+func (_c *MockCacheStorage_GetWithTTL_Call) Return(_a0 []byte, _a1 time.Duration, _a2 error) *MockCacheStorage_GetWithTTL_Call {
 	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MockCacheStorage_GetWithTTL_Call) RunAndReturn(run func(context.Context, string) (string, time.Duration, error)) *MockCacheStorage_GetWithTTL_Call {
+func (_c *MockCacheStorage_GetWithTTL_Call) RunAndReturn(run func(context.Context, string) ([]byte, time.Duration, error)) *MockCacheStorage_GetWithTTL_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Set provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *MockCacheStorage) Set(_a0 context.Context, _a1 string, _a2 string, _a3 time.Duration) error {
+func (_m *MockCacheStorage) Set(_a0 context.Context, _a1 string, _a2 []byte, _a3 time.Duration) error {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	if len(ret) == 0 {
@@ -256,7 +215,7 @@ func (_m *MockCacheStorage) Set(_a0 context.Context, _a1 string, _a2 string, _a3
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, []byte, time.Duration) error); ok {
 		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r0 = ret.Error(0)
@@ -273,15 +232,15 @@ type MockCacheStorage_Set_Call struct {
 // Set is a helper method to define mock.On call
 //   - _a0 context.Context
 //   - _a1 string
-//   - _a2 string
+//   - _a2 []byte
 //   - _a3 time.Duration
 func (_e *MockCacheStorage_Expecter) Set(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}) *MockCacheStorage_Set_Call {
 	return &MockCacheStorage_Set_Call{Call: _e.mock.On("Set", _a0, _a1, _a2, _a3)}
 }
 
-func (_c *MockCacheStorage_Set_Call) Run(run func(_a0 context.Context, _a1 string, _a2 string, _a3 time.Duration)) *MockCacheStorage_Set_Call {
+func (_c *MockCacheStorage_Set_Call) Run(run func(_a0 context.Context, _a1 string, _a2 []byte, _a3 time.Duration)) *MockCacheStorage_Set_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(time.Duration))
+		run(args[0].(context.Context), args[1].(string), args[2].([]byte), args[3].(time.Duration))
 	})
 	return _c
 }
@@ -291,7 +250,7 @@ func (_c *MockCacheStorage_Set_Call) Return(_a0 error) *MockCacheStorage_Set_Cal
 	return _c
 }
 
-func (_c *MockCacheStorage_Set_Call) RunAndReturn(run func(context.Context, string, string, time.Duration) error) *MockCacheStorage_Set_Call {
+func (_c *MockCacheStorage_Set_Call) RunAndReturn(run func(context.Context, string, []byte, time.Duration) error) *MockCacheStorage_Set_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -56,14 +56,14 @@ func New(limit int) (*Storage, error) {
 }
 
 // Get retrieves the value associated with the provided key from the in-memory cache storage.
-func (s *Storage) Get(_ context.Context, key string) (string, error) {
+func (s *Storage) Get(_ context.Context, key string) ([]byte, error) {
 	value, _, err := s.GetWithTTL(context.Background(), key)
 
 	return value, err
 }
 
 // Set stores a value associated with the provided key in the in-memory cache storage.
-func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) error {
+func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
 	if s.ctx.Err() != nil {
 		return errors.New("storage is closed")
 	}
@@ -93,7 +93,7 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 	}
 
 	item := &cacheItem{
-		value:  []byte(value),
+		value:  value,
 		expiry: expiry,
 	}
 
@@ -149,9 +149,9 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 }
 
 // GetWithTTL retrieves the value and time-to-live (TTL) associated with the provided key from the in-memory cache storage.
-func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Duration, error) {
+func (s *Storage) GetWithTTL(_ context.Context, key string) ([]byte, time.Duration, error) {
 	if s.ctx.Err() != nil {
-		return "", 0, errors.New("storage is closed")
+		return nil, 0, errors.New("storage is closed")
 	}
 
 	s.mu.Lock()
@@ -160,24 +160,24 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) (string, time.Durati
 	item, ok := s.index[key]
 
 	if !ok {
-		return "", 0, anycache.ErrKeyNotExists
+		return nil, 0, anycache.ErrKeyNotExists
 	}
 
 	if item.expiry == nil {
 		s.items.MoveToBack(item.lruPos)
-		return string(item.value), 0, nil
+		return item.value, 0, nil
 	}
 
 	ttl := time.Until(*item.expiry)
 	if ttl <= 0 {
 		s.delete(item)
 
-		return "", 0, anycache.ErrKeyNotExists
+		return nil, 0, anycache.ErrKeyNotExists
 	}
 
 	s.items.MoveToBack(item.lruPos)
 
-	return string(item.value), ttl, nil
+	return item.value, ttl, nil
 }
 
 // Close gracefully shuts down the in-memory cache storage, ensuring that all resources are released and any ongoing operations are completed.

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -5,6 +5,7 @@ import (
 	"container/list"
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"time"
 
@@ -93,6 +94,7 @@ func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Dura
 	}
 
 	item := &cacheItem{
+		key:    key,
 		value:  value,
 		expiry: expiry,
 	}
@@ -165,7 +167,7 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) ([]byte, time.Durati
 
 	if item.expiry == nil {
 		s.items.MoveToBack(item.lruPos)
-		return item.value, 0, nil
+		return slices.Clone(item.value), 0, nil
 	}
 
 	ttl := time.Until(*item.expiry)
@@ -177,7 +179,7 @@ func (s *Storage) GetWithTTL(_ context.Context, key string) ([]byte, time.Durati
 
 	s.items.MoveToBack(item.lruPos)
 
-	return item.value, ttl, nil
+	return slices.Clone(item.value), ttl, nil
 }
 
 // Close gracefully shuts down the in-memory cache storage, ensuring that all resources are released and any ongoing operations are completed.

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"gotest.tools/v3/assert"
 )
 
 func TestNew(t *testing.T) {
@@ -66,7 +68,7 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err := s.Set(t.Context(), "key1", "value1", 0); err != nil {
+				if err := s.Set(t.Context(), "key1", []byte("value1"), 0); err != nil {
 					t.Fatalf("Failed to set key1: %v", err)
 				}
 
@@ -102,7 +104,7 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err := s.Set(t.Context(), "key2", "value2", time.Microsecond); err != nil {
+				if err := s.Set(t.Context(), "key2", []byte("value2"), time.Microsecond); err != nil {
 					t.Fatalf("Failed to set key2: %v", err)
 				}
 
@@ -134,9 +136,7 @@ func TestInMemoryCacheStorage_Get(t *testing.T) {
 				t.Fatal("Get() succeeded unexpectedly")
 			}
 
-			if tt.want != got {
-				t.Errorf("Get() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, string(got), "Expected to get %v, but got '%v'", tt.want, string(got))
 		})
 	}
 }
@@ -145,7 +145,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 	tests := []struct {
 		name          string
 		key           string
-		value         string
+		value         []byte
 		ttl           time.Duration
 		waitBeforeGet time.Duration
 		wantErr       bool
@@ -154,7 +154,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 		{
 			name:          "Successfully set a value for a key with no TTL",
 			key:           "key1",
-			value:         "value1",
+			value:         []byte("value1"),
 			wantErr:       false,
 			waitBeforeGet: 0,
 			ableToGet:     true,
@@ -162,7 +162,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 		{
 			name:          "Successfully set a value for a key with a TTL and retrieve it before expiration",
 			key:           "key2",
-			value:         "value2",
+			value:         []byte("value2"),
 			ttl:           2 * time.Millisecond,
 			wantErr:       false,
 			waitBeforeGet: time.Millisecond,
@@ -171,7 +171,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 		{
 			name:          "Successfully set a value for a key with a TTL and fail to retrieve it after expiration",
 			key:           "key3",
-			value:         "value3",
+			value:         []byte("value3"),
 			ttl:           time.Millisecond,
 			wantErr:       false,
 			waitBeforeGet: 2 * time.Millisecond,
@@ -180,7 +180,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 		{
 			name:          "Error when setting a value for a key with an invalid TTL",
 			key:           "key4",
-			value:         "value4",
+			value:         []byte("value4"),
 			ttl:           -time.Second,
 			wantErr:       true,
 			waitBeforeGet: 0,
@@ -215,10 +215,10 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 
 			value, err := s.Get(t.Context(), tt.key)
 
-			if tt.ableToGet && tt.value != value {
-				t.Errorf("Get() = %v, want %v, err %v", value, tt.value, err)
-			} else if !tt.ableToGet && err == nil {
-				t.Fatal("Get() succeeded unexpectedly")
+			if tt.ableToGet {
+				assert.Equal(t, tt.value, value, "Expected to get %v, but got '%v'", tt.value, value)
+			} else {
+				assert.Error(t, err, "Expected to get an error, but got nil")
 			}
 		})
 	}
@@ -244,7 +244,7 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err = s.Set(t.Context(), "key1", "value1", 0); err != nil {
+				if err = s.Set(t.Context(), "key1", []byte("value1"), 0); err != nil {
 					t.Fatalf("Failed to set key1: %v", err)
 				}
 
@@ -265,7 +265,7 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err = s.Set(t.Context(), "key2", "value2", time.Millisecond); err != nil {
+				if err = s.Set(t.Context(), "key2", []byte("value2"), time.Millisecond); err != nil {
 					t.Fatalf("Failed to set key2: %v", err)
 				}
 
@@ -286,7 +286,7 @@ func TestInMemoryCacheStorage_TTL(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err = s.Set(t.Context(), "key3", "value3", time.Millisecond); err != nil {
+				if err = s.Set(t.Context(), "key3", []byte("value3"), time.Millisecond); err != nil {
 					t.Fatalf("Failed to set key3: %v", err)
 				}
 
@@ -352,7 +352,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err := s.Set(t.Context(), "key1", "value1", 0); err != nil {
+				if err := s.Set(t.Context(), "key1", []byte("value1"), 0); err != nil {
 					t.Fatalf("Failed to set key1: %v", err)
 				}
 
@@ -372,7 +372,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err := s.Set(t.Context(), "key1", "value1", 0); err != nil {
+				if err := s.Set(t.Context(), "key1", []byte("value1"), 0); err != nil {
 					t.Fatalf("Failed to set key1: %v", err)
 				}
 
@@ -392,7 +392,7 @@ func TestInMemoryCacheStorage_Del(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err := s.Set(t.Context(), "key3", "value3", time.Millisecond); err != nil {
+				if err := s.Set(t.Context(), "key3", []byte("value3"), time.Millisecond); err != nil {
 					t.Fatalf("Failed to set key3: %v", err)
 				}
 
@@ -449,7 +449,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err = s.Set(t.Context(), "key1", "value1", time.Millisecond); err != nil {
+				if err = s.Set(t.Context(), "key1", []byte("value1"), time.Millisecond); err != nil {
 					t.Fatalf("Failed to set key1: %v", err)
 				}
 
@@ -470,7 +470,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err = s.Set(t.Context(), "key1", "value1", time.Millisecond); err != nil {
+				if err = s.Set(t.Context(), "key1", []byte("value1"), time.Millisecond); err != nil {
 					t.Fatalf("Failed to set key1: %v", err)
 				}
 
@@ -491,7 +491,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 				}
 
-				if err = s.Set(t.Context(), "key2", "value2", time.Millisecond); err != nil {
+				if err = s.Set(t.Context(), "key2", []byte("value2"), time.Millisecond); err != nil {
 					t.Fatalf("Failed to set key2: %v", err)
 				}
 
@@ -523,9 +523,7 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 				t.Fatal("GetWithTTL() succeeded unexpectedly")
 			}
 
-			if tt.want != got {
-				t.Errorf("GetWithTTL() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, string(got), "Expected to get %v, but got '%v'", tt.want, string(got))
 
 			if tt.want2 > 0 && got2 > 0 && tt.want2 < got2 {
 				t.Errorf("GetWithTTL() = %v, want %v", got2, tt.want2)
@@ -544,7 +542,7 @@ func TestInMemoryCacheStorage_Close(t *testing.T) {
 		t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
 	}
 
-	err = s.Set(t.Context(), "key1", "value1", 0)
+	err = s.Set(t.Context(), "key1", []byte("value1"), 0)
 	if err != nil {
 		t.Fatalf("Failed to set key1: %v", err)
 	}
@@ -559,7 +557,7 @@ func TestInMemoryCacheStorage_Close(t *testing.T) {
 		t.Fatalf("Failed to close InMemoryCacheStorage: %v", err)
 	}
 
-	err = s.Set(t.Context(), "key2", "value2", 0)
+	err = s.Set(t.Context(), "key2", []byte("value2"), 0)
 	if err == nil {
 		t.Fatal("Set() succeeded unexpectedly after Close()")
 	}

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNew(t *testing.T) {

--- a/storage/memcache/memcache.go
+++ b/storage/memcache/memcache.go
@@ -1,4 +1,4 @@
-package memcachestor
+package memcache
 
 import (
 	"context"
@@ -10,20 +10,20 @@ import (
 	"github.com/ksysoev/anycache"
 )
 
-type MemcachedCacheStorage struct {
+type Storage struct {
 	memcache *memcache.Client
 }
 
 // NewRedisCacheStorage creates a new RedisCacheStorage
-func NewMemcachedCacheStorage(client *memcache.Client) *MemcachedCacheStorage {
-	return &MemcachedCacheStorage{client}
+func New(client *memcache.Client) *Storage {
+	return &Storage{client}
 }
 
 // Get retrieves the value associated with the provided key from the Memcached cache storage.
 // It returns the value as a string and an error if any occurred.
 // If the key does not exist, it returns an empty string and a ErrKeyNotExists.
 // If any other error occurs during the operation, it returns an empty string and the error.
-func (s *MemcachedCacheStorage) Get(_ context.Context, key string) (string, error) {
+func (s *Storage) Get(_ context.Context, key string) (string, error) {
 	item, err := s.memcache.Get(key)
 
 	if errors.Is(err, memcache.ErrCacheMiss) {
@@ -41,7 +41,7 @@ func (s *MemcachedCacheStorage) Get(_ context.Context, key string) (string, erro
 // It also accepts options which currently only includes TTL (time-to-live) for the key-value pair.
 // If the TTL is greater than 0, the key-value pair will be automatically removed from the cache after the TTL duration.
 // If the TTL is 0 or less, the key-value pair will persist in the cache until it is manually removed.
-func (s *MemcachedCacheStorage) Set(_ context.Context, key, value string, ttl time.Duration) error {
+func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) error {
 	if ttl.Seconds() > math.MaxInt32 {
 		return errors.New("TTL value is too large")
 	}
@@ -68,7 +68,7 @@ func (s *MemcachedCacheStorage) Set(_ context.Context, key, value string, ttl ti
 // If the key does not exist, it returns false, a zero duration, and a ErrKeyNotExists.
 // If the key exists but does not have an expiration, it returns false, a zero duration, and nil error.
 // If the key exists and has an expiration, it returns true, the TTL, and nil error.
-func (s *MemcachedCacheStorage) TTL(_ context.Context, key string) (bool, time.Duration, error) {
+func (s *Storage) TTL(_ context.Context, key string) (bool, time.Duration, error) {
 	var ttl time.Duration
 
 	hasTTL := false
@@ -92,7 +92,7 @@ func (s *MemcachedCacheStorage) TTL(_ context.Context, key string) (bool, time.D
 // Del deletes the value associated with the provided key from the Memcached cache storage.
 // It returns a boolean indicating whether the deletion was successful, and an error if any occurred.
 // If the key does not exist or any other error occurs during the operation, it returns false and the error.
-func (s *MemcachedCacheStorage) Del(_ context.Context, key string) (bool, error) {
+func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 	err := s.memcache.Delete(key)
 	if err != nil {
 		return false, err
@@ -105,7 +105,7 @@ func (s *MemcachedCacheStorage) Del(_ context.Context, key string) (bool, error)
 // It returns the value as a string, the time-to-live (TTL) as a time.Duration, and an error if any occurred.
 // Currently, the TTL is always returned as 0 because this function does not support retrieving the TTL from Memcached.
 // If the key does not exist or any other error occurs during the operation, it returns the error and the TTL as 0.
-func (s *MemcachedCacheStorage) GetWithTTL(ctx context.Context, key string) (string, time.Duration, error) {
+func (s *Storage) GetWithTTL(ctx context.Context, key string) (string, time.Duration, error) {
 	value, err := s.Get(ctx, key)
 	if err != nil {
 		return value, 0, err
@@ -115,6 +115,6 @@ func (s *MemcachedCacheStorage) GetWithTTL(ctx context.Context, key string) (str
 }
 
 // Close closes the connection to the Memcached server.
-func (s *MemcachedCacheStorage) Close() error {
+func (s *Storage) Close() error {
 	return s.memcache.Close()
 }

--- a/storage/memcache/memcache.go
+++ b/storage/memcache/memcache.go
@@ -20,34 +20,34 @@ func New(client *memcache.Client) *Storage {
 }
 
 // Get retrieves the value associated with the provided key from the Memcached cache storage.
-// It returns the value as a string and an error if any occurred.
-// If the key does not exist, it returns an empty string and a ErrKeyNotExists.
-// If any other error occurs during the operation, it returns an empty string and the error.
-func (s *Storage) Get(_ context.Context, key string) (string, error) {
+// It returns the value as a byte array and an error if any occurred.
+// If the key does not exist, it returns a nil and a ErrKeyNotExists.
+// If any other error occurs during the operation, it returns a nil and the error.
+func (s *Storage) Get(_ context.Context, key string) ([]byte, error) {
 	item, err := s.memcache.Get(key)
 
 	if errors.Is(err, memcache.ErrCacheMiss) {
-		return "", anycache.ErrKeyNotExists
+		return nil, anycache.ErrKeyNotExists
 	}
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return string(item.Value), nil
+	return item.Value, nil
 }
 
 // Set stores a value associated with the provided key in the Memcached cache storage.
 // It also accepts options which currently only includes TTL (time-to-live) for the key-value pair.
 // If the TTL is greater than 0, the key-value pair will be automatically removed from the cache after the TTL duration.
 // If the TTL is 0 or less, the key-value pair will persist in the cache until it is manually removed.
-func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) error {
+func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
 	if ttl.Seconds() > math.MaxInt32 {
 		return errors.New("TTL value is too large")
 	}
 
 	if ttl > 0 {
-		err := s.memcache.Set(&memcache.Item{Key: key, Value: []byte(value), Expiration: int32(ttl.Seconds())})
+		err := s.memcache.Set(&memcache.Item{Key: key, Value: value, Expiration: int32(ttl.Seconds())})
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ func (s *Storage) Set(_ context.Context, key, value string, ttl time.Duration) e
 		return nil
 	}
 
-	err := s.memcache.Set(&memcache.Item{Key: key, Value: []byte(value)})
+	err := s.memcache.Set(&memcache.Item{Key: key, Value: value})
 	if err != nil {
 		return err
 	}
@@ -105,16 +105,11 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 // It returns the value as a string, the time-to-live (TTL) as a time.Duration, and an error if any occurred.
 // Currently, the TTL is always returned as 0 because this function does not support retrieving the TTL from Memcached.
 // If the key does not exist or any other error occurs during the operation, it returns the error and the TTL as 0.
-func (s *Storage) GetWithTTL(ctx context.Context, key string) (string, time.Duration, error) {
+func (s *Storage) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, error) {
 	value, err := s.Get(ctx, key)
 	if err != nil {
 		return value, 0, err
 	}
 
 	return value, 0, nil
-}
-
-// Close closes the connection to the Memcached server.
-func (s *Storage) Close() error {
-	return s.memcache.Close()
 }

--- a/storage/memcache/memcache.go
+++ b/storage/memcache/memcache.go
@@ -14,7 +14,7 @@ type Storage struct {
 	memcache *memcache.Client
 }
 
-// NewRedisCacheStorage creates a new RedisCacheStorage
+// New creates a new memcache cache storage with the provided memcache client.
 func New(client *memcache.Client) *Storage {
 	return &Storage{client}
 }
@@ -102,7 +102,7 @@ func (s *Storage) Del(_ context.Context, key string) (bool, error) {
 }
 
 // GetWithTTL retrieves the value associated with the provided key from the Memcached cache storage.
-// It returns the value as a string, the time-to-live (TTL) as a time.Duration, and an error if any occurred.
+// It returns the value as a byte array, the time-to-live (TTL) as a time.Duration, and an error if any occurred.
 // Currently, the TTL is always returned as 0 because this function does not support retrieving the TTL from Memcached.
 // If the key does not exist or any other error occurs during the operation, it returns the error and the TTL as 0.
 func (s *Storage) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, error) {

--- a/storage/memcache/memcache_test.go
+++ b/storage/memcache/memcache_test.go
@@ -1,4 +1,4 @@
-package memcachestor
+package memcache
 
 import (
 	"context"
@@ -28,7 +28,7 @@ func getMemcachedHost() string {
 
 func TestMemcacheCacheStorageGet(t *testing.T) {
 	memcachedClient := memcache.New(getMemcachedHost())
-	memcacheStore := NewMemcachedCacheStorage(memcachedClient)
+	memcacheStore := New(memcachedClient)
 
 	ctx := context.Background()
 
@@ -55,7 +55,7 @@ func TestMemcacheCacheStorageGet(t *testing.T) {
 
 func TestMemcacheCacheStorageSet(t *testing.T) {
 	memcachedClient := memcache.New(getMemcachedHost())
-	memcacheStore := NewMemcachedCacheStorage(memcachedClient)
+	memcacheStore := New(memcachedClient)
 
 	ctx := context.Background()
 
@@ -84,7 +84,7 @@ func TestMemcacheCacheStorageSet(t *testing.T) {
 
 func TestMemcacheCacheStorageTTL(t *testing.T) {
 	memcachedClient := memcache.New(getMemcachedHost())
-	memcacheStore := NewMemcachedCacheStorage(memcachedClient)
+	memcacheStore := New(memcachedClient)
 
 	ctx := context.Background()
 
@@ -129,7 +129,7 @@ func TestMemcacheCacheStorageTTL(t *testing.T) {
 
 func TestMemcacheCacheStorageDel(t *testing.T) {
 	memcachedClient := memcache.New(getMemcachedHost())
-	memcacheStore := NewMemcachedCacheStorage(memcachedClient)
+	memcacheStore := New(memcachedClient)
 
 	ctx := context.Background()
 

--- a/storage/memcache/memcache_test.go
+++ b/storage/memcache/memcache_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/ksysoev/anycache"
+	"gotest.tools/v3/assert"
 )
 
 func getMemcachedHost() string {
@@ -42,9 +43,7 @@ func TestMemcacheCacheStorageGet(t *testing.T) {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
 
-	if value != "testValue" {
-		t.Errorf("Expected to get testValue, but got '%v'", value)
-	}
+	assert.Equal(t, []byte("testValue"), value, "Expected to get testValue, but got '%v'", value)
 
 	_, err = memcacheStore.Get(ctx, "TestMemcacheCacheStorageGetKey1")
 
@@ -59,7 +58,7 @@ func TestMemcacheCacheStorageSet(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := memcacheStore.Set(ctx, "TestMemcacheCacheStorageSetKey", "testValue", 0)
+	err := memcacheStore.Set(ctx, "TestMemcacheCacheStorageSetKey", []byte("testValue"), 0)
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -70,7 +69,7 @@ func TestMemcacheCacheStorageSet(t *testing.T) {
 		t.Errorf("Expected to get testValue, but got '%v'", item.Value)
 	}
 
-	err = memcacheStore.Set(ctx, "TestMemcacheCacheStorageSetKey1", "testValue", 2*time.Second)
+	err = memcacheStore.Set(ctx, "TestMemcacheCacheStorageSetKey1", []byte("testValue"), 2*time.Second)
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}

--- a/storage/memcache/memcache_test.go
+++ b/storage/memcache/memcache_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/ksysoev/anycache"
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func getMemcachedHost() string {

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -19,18 +19,18 @@ func NewRedisCacheStorage(redisDB *redis.Client) *RedisCacheStorage {
 }
 
 // Get retrieves the value associated with the provided key from the Redis cache storage.
-// It returns the value as a string and an error if any occurred.
-// If the key does not exist, it returns an empty string and a ErrKeyNotExists.
-// If any other error occurs during the operation, it returns an empty string and the error.
-func (s *RedisCacheStorage) Get(ctx context.Context, key string) (string, error) {
-	item, err := s.redisDB.Get(ctx, key).Result()
+// It returns the value as a byte array and an error if any occurred.
+// If the key does not exist, it returns a nil and a ErrKeyNotExists.
+// If any other error occurs during the operation, it returns a nil and the error.
+func (s *RedisCacheStorage) Get(ctx context.Context, key string) ([]byte, error) {
+	item, err := s.redisDB.Get(ctx, key).Bytes()
 
 	if errors.Is(err, redis.Nil) {
-		return "", anycache.ErrKeyNotExists
+		return nil, anycache.ErrKeyNotExists
 	}
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	return item, nil
@@ -41,7 +41,7 @@ func (s *RedisCacheStorage) Get(ctx context.Context, key string) (string, error)
 // If the TTL is greater than 0, the key-value pair will be automatically removed from the cache after the TTL duration.
 // If the TTL is 0 or less, the key-value pair will persist in the cache until it is manually removed.
 // If an error occurs during the operation, it returns the error.
-func (s *RedisCacheStorage) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+func (s *RedisCacheStorage) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
 	if ttl > 0 {
 		err := s.redisDB.Set(ctx, key, value, ttl).Err()
 		if err != nil {
@@ -104,11 +104,11 @@ func (s *RedisCacheStorage) Del(ctx context.Context, key string) (bool, error) {
 }
 
 // GetWithTTL retrieves the value and time-to-live (TTL) associated with the provided key from the Redis cache storage.
-// It returns the value as a string, the TTL as a time.Duration, and an error if any occurred.
-// If the key does not exist, it returns an empty string, a zero duration, and a ErrKeyNotExists.
+// It returns the value as a byte array, the TTL as a time.Duration, and an error if any occurred.
+// If the key does not exist, it returns a nil, a zero duration, and a ErrKeyNotExists.
 // If the key exists but does not have an expiration, it returns the value, a zero duration, and nil error.
 // If the key exists and has an expiration, it returns the value, the TTL, and nil error.
-func (s *RedisCacheStorage) GetWithTTL(ctx context.Context, key string) (string, time.Duration, error) {
+func (s *RedisCacheStorage) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, error) {
 	value, err := s.Get(ctx, key)
 	if err != nil {
 		return value, 0, err
@@ -124,9 +124,4 @@ func (s *RedisCacheStorage) GetWithTTL(ctx context.Context, key string) (string,
 	}
 
 	return value, ttl, nil
-}
-
-// Close closes the Redis cache storage connection.
-func (s *RedisCacheStorage) Close() error {
-	return s.redisDB.Close()
 }

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -1,4 +1,4 @@
-package redisstor
+package redis
 
 import (
 	"context"
@@ -9,20 +9,20 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-type RedisCacheStorage struct {
+type Storage struct {
 	redisDB *redis.Client
 }
 
-// NewRedisCacheStorage creates a new RedisCacheStorage
-func NewRedisCacheStorage(redisDB *redis.Client) *RedisCacheStorage {
-	return &RedisCacheStorage{redisDB: redisDB}
+// New creates a new RedisCacheStorage
+func New(redisDB *redis.Client) *Storage {
+	return &Storage{redisDB: redisDB}
 }
 
 // Get retrieves the value associated with the provided key from the Redis cache storage.
 // It returns the value as a byte array and an error if any occurred.
 // If the key does not exist, it returns a nil and a ErrKeyNotExists.
 // If any other error occurs during the operation, it returns a nil and the error.
-func (s *RedisCacheStorage) Get(ctx context.Context, key string) ([]byte, error) {
+func (s *Storage) Get(ctx context.Context, key string) ([]byte, error) {
 	item, err := s.redisDB.Get(ctx, key).Bytes()
 
 	if errors.Is(err, redis.Nil) {
@@ -41,7 +41,7 @@ func (s *RedisCacheStorage) Get(ctx context.Context, key string) ([]byte, error)
 // If the TTL is greater than 0, the key-value pair will be automatically removed from the cache after the TTL duration.
 // If the TTL is 0 or less, the key-value pair will persist in the cache until it is manually removed.
 // If an error occurs during the operation, it returns the error.
-func (s *RedisCacheStorage) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+func (s *Storage) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
 	if ttl > 0 {
 		err := s.redisDB.Set(ctx, key, value, ttl).Err()
 		if err != nil {
@@ -63,7 +63,7 @@ func (s *RedisCacheStorage) Set(ctx context.Context, key string, value []byte, t
 // It returns a boolean indicating whether the deletion was successful, and an error if any occurred.
 // If the key does not exist, it returns false and nil error.
 // If any other error occurs during the operation, it returns false and the error.
-func (s *RedisCacheStorage) TTL(ctx context.Context, key string) (bool, time.Duration, error) {
+func (s *Storage) TTL(ctx context.Context, key string) (bool, time.Duration, error) {
 	var ttl time.Duration
 
 	hasTTL := false
@@ -92,7 +92,7 @@ func (s *RedisCacheStorage) TTL(ctx context.Context, key string) (bool, time.Dur
 // It returns a boolean indicating whether the deletion was successful, and an error if any occurred.
 // If the key does not exist, it returns false and nil error.
 // If any other error occurs during the operation, it returns false and the error.
-func (s *RedisCacheStorage) Del(ctx context.Context, key string) (bool, error) {
+func (s *Storage) Del(ctx context.Context, key string) (bool, error) {
 	deleted, err := s.redisDB.Del(ctx, key).Result()
 	if err != nil {
 		return false, err
@@ -108,7 +108,7 @@ func (s *RedisCacheStorage) Del(ctx context.Context, key string) (bool, error) {
 // If the key does not exist, it returns a nil, a zero duration, and a ErrKeyNotExists.
 // If the key exists but does not have an expiration, it returns the value, a zero duration, and nil error.
 // If the key exists and has an expiration, it returns the value, the TTL, and nil error.
-func (s *RedisCacheStorage) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, error) {
+func (s *Storage) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, error) {
 	value, err := s.Get(ctx, key)
 	if err != nil {
 		return value, 0, err

--- a/storage/redis/redis_test.go
+++ b/storage/redis/redis_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ksysoev/anycache"
 	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 )
 
 func getRedisOptions() *redis.Options {
@@ -39,9 +40,7 @@ func TestRedisCacheStorageGet(t *testing.T) {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
 
-	if value != "testValue" {
-		t.Errorf("Expected to get testValue, but got '%v'", value)
-	}
+	assert.Equal(t, []byte("testValue"), value, "Expected to get testValue, but got '%v'", value)
 
 	_, err = redisStore.Get(ctx, "TestRedisCacheStorageGetKey1")
 
@@ -56,7 +55,7 @@ func TestRedisCacheStorageSet(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := redisStore.Set(ctx, "TestRedisCacheStorageSetKey", "testValue", 0)
+	err := redisStore.Set(ctx, "TestRedisCacheStorageSetKey", []byte("testValue"), 0)
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -67,7 +66,7 @@ func TestRedisCacheStorageSet(t *testing.T) {
 		t.Errorf("Expected to get testValue, but got '%v'", val)
 	}
 
-	err = redisStore.Set(ctx, "TestRedisCacheStorageSetKey1", "testValue", 2*time.Second)
+	err = redisStore.Set(ctx, "TestRedisCacheStorageSetKey1", []byte("testValue"), 2*time.Second)
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}

--- a/storage/redis/redis_test.go
+++ b/storage/redis/redis_test.go
@@ -1,4 +1,4 @@
-package redisstor
+package redis
 
 import (
 	"context"
@@ -29,7 +29,7 @@ func getRedisOptions() *redis.Options {
 
 func TestRedisCacheStorageGet(t *testing.T) {
 	redisClient := redis.NewClient(getRedisOptions())
-	redisStore := NewRedisCacheStorage(redisClient)
+	redisStore := New(redisClient)
 
 	ctx := context.Background()
 
@@ -51,7 +51,7 @@ func TestRedisCacheStorageGet(t *testing.T) {
 
 func TestRedisCacheStorageSet(t *testing.T) {
 	redisClient := redis.NewClient(getRedisOptions())
-	redisStore := NewRedisCacheStorage(redisClient)
+	redisStore := New(redisClient)
 
 	ctx := context.Background()
 
@@ -86,7 +86,7 @@ func TestRedisCacheStorageSet(t *testing.T) {
 
 func TestRedisCacheStorageTTL(t *testing.T) {
 	redisClient := redis.NewClient(getRedisOptions())
-	redisStore := NewRedisCacheStorage(redisClient)
+	redisStore := New(redisClient)
 
 	ctx := context.Background()
 
@@ -125,7 +125,7 @@ func TestRedisCacheStorageTTL(t *testing.T) {
 
 func TestRedisCacheStorageDel(t *testing.T) {
 	redisClient := redis.NewClient(getRedisOptions())
-	redisStore := NewRedisCacheStorage(redisClient)
+	redisStore := New(redisClient)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This pull request refactors the cache storage interface and its implementations to use `[]byte` instead of `string` for cached values. This change improves flexibility and efficiency when storing binary or non-string data. The update touches the main cache interfaces, the in-memory storage implementation, and all related tests and mocks.

Key changes include:

**API and Interface Changes:**

- Updated the `CacheStorage` interface and related types in `anycache.go` to use `[]byte` instead of `string` for all cache values and generator functions, affecting `Get`, `Set`, `GetWithTTL`, and `CacheGenerator`. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L25-R29) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L50-R50) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L183-R194) [[4]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L222-R222)

**Implementation Updates:**

- Modified the in-memory cache implementation in `storage/inmemory/inmemory.go` to handle `[]byte` values throughout, including in the `Get`, `Set`, and `GetWithTTL` methods. [[1]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L59-R66) [[2]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L96-R96) [[3]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L152-R154) [[4]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L163-R180)

**Testing and Mock Adjustments:**

- Updated all tests in `anycache_test.go` and `storage/inmemory/inmemory_test.go` to use `[]byte` for cache values, including changes to test helpers and assertions. [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL13-R14) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL23-R26) [[3]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL35-R37) [[4]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL53-R67) [[5]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL87-R90) [[6]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL113-R113) [[7]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL145-R151) [[8]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6L69-R71) [[9]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6L105-R107) [[10]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6L137-R139)
- Refactored the mock cache storage in `cache_storage_mock.go` to match the new `[]byte` signatures for all relevant methods. Also removed the unused `Close` method from the mock. [[1]](diffhunk://#diff-db3dee46775bde588fb0e362da61219a5685f30e0e8e1837c81602efa40e7c33L27-L71) [[2]](diffhunk://#diff-db3dee46775bde588fb0e362da61219a5685f30e0e8e1837c81602efa40e7c33L130-R102) [[3]](diffhunk://#diff-db3dee46775bde588fb0e362da61219a5685f30e0e8e1837c81602efa40e7c33L176-R162) [[4]](diffhunk://#diff-db3dee46775bde588fb0e362da61219a5685f30e0e8e1837c81602efa40e7c33L240-R218) [[5]](diffhunk://#diff-db3dee46775bde588fb0e362da61219a5685f30e0e8e1837c81602efa40e7c33L276-R243) [[6]](diffhunk://#diff-db3dee46775bde588fb0e362da61219a5685f30e0e8e1837c81602efa40e7c33L294-R253)

**Other Improvements:**

- Minor: Added `testify/assert` import for improved test assertions.

These changes make the cache system more robust and suitable for a wider range of use cases by supporting binary data and not just strings.