### PR TITLE
Adds possibility to define custom key prefix

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -39,6 +39,7 @@ type Cache struct {
 	cancel      chan *CacheReuest
 	wg          sync.WaitGroup
 	maxShiftTTL uint8
+	keyPrefix   string
 }
 
 type CacheReuest struct {
@@ -74,13 +75,6 @@ func New(store CacheStorage, opts ...CacheOptions) *Cache {
 	return &c
 }
 
-// WithTTLRandomization sets max shift of TTL in persent
-func WithTTLRandomization(maxShiftPercent uint8) func(*Cache) {
-	return func(c *Cache) {
-		c.maxShiftTTL = maxShiftPercent
-	}
-}
-
 // WithTTL sets TTL for cache item
 func WithTTL(ttl time.Duration) CacheItemOptions {
 	return func(req *CacheReuest) {
@@ -108,6 +102,8 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 	for _, opt := range opts {
 		opt(&req)
 	}
+
+	key = c.keyPrefix + key
 
 	res := c.sf.DoChan(key, func() (value any, err error) {
 		defer func() {
@@ -228,6 +224,8 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 // accepts a context and the key to be invalidated.
 // returns an error if there was a problem invalidating the cache for the key.
 func (c *Cache) Invalidate(ctx context.Context, key string) error {
+	key = c.keyPrefix + key
+
 	_, err := c.Storage.Del(ctx, key)
 	if err != nil {
 		return fmt.Errorf("failed to invalidate cache for key %s: %w", key, err)

--- a/anycache.go
+++ b/anycache.go
@@ -37,9 +37,9 @@ type Cache struct {
 	warmUpSF    singleflight.Group
 	cancelCtx   context.CancelFunc
 	cancel      chan *CacheReuest
+	keyPrefix   string
 	wg          sync.WaitGroup
 	maxShiftTTL uint8
-	keyPrefix   string
 }
 
 type CacheReuest struct {

--- a/cache_options.go
+++ b/cache_options.go
@@ -1,0 +1,22 @@
+package anycache
+
+// WithTTLRandomization sets max shift of TTL in persent
+// TTL randomization is a technique used to prevent cache stampedes by adding a random shift to the TTL (time-to-live) of cache entries.
+// This helps to distribute the expiration times of cache entries more evenly,
+// reducing the likelihood of multiple entries expiring at the same time and causing a surge in traffic to the underlying data source.
+// The maxShiftPercent parameter specifies the maximum percentage by which the TTL can be shifted randomly. For example,
+// if maxShiftPercent is set to 20, then the TTL of a cache entry can be randomly shifted by up to 20% of its original value.
+func WithTTLRandomization(maxShiftPercent uint8) func(*Cache) {
+	return func(c *Cache) {
+		c.maxShiftTTL = maxShiftPercent
+	}
+}
+
+// WithKeyPrefix sets default key prefix for cache keys
+// Key prefix is a string that is added to the beginning of cache keys before they are stored in the cache.
+// This can be useful for namespacing cache entries, preventing key collisions, and organizing cache data.
+func WithKeyPrefix(prefix string) func(*Cache) {
+	return func(c *Cache) {
+		c.keyPrefix = prefix
+	}
+}

--- a/cache_options.go
+++ b/cache_options.go
@@ -1,7 +1,7 @@
 package anycache
 
 const (
-	maxTTlShift = 100
+	maxTTLShift = 100
 )
 
 // WithTTLRandomization sets the maximum TTL shift percentage.
@@ -9,8 +9,8 @@ const (
 // maximum shift percentage is 100, which means that TTL can be shifted by up to 100% of the original TTL value.
 func WithTTLRandomization(shiftPercent uint8) func(*Cache) {
 	return func(c *Cache) {
-		if shiftPercent > maxTTlShift {
-			c.maxShiftTTL = maxTTlShift
+		if shiftPercent > maxTTLShift {
+			c.maxShiftTTL = maxTTLShift
 
 			return
 		}

--- a/cache_options.go
+++ b/cache_options.go
@@ -1,11 +1,21 @@
 package anycache
 
+const (
+	maxTTlShift = 100
+)
+
 // WithTTLRandomization sets the maximum TTL shift percentage.
 // TTL randomization helps prevent cache stampedes by spreading entry expirations over time.
-// Note: the current implementation shifts TTL within roughly ±(maxShiftPercent/2)% of the original TTL.
-func WithTTLRandomization(maxShiftPercent uint8) func(*Cache) {
+// maximum shift percentage is 100, which means that TTL can be shifted by up to 100% of the original TTL value.
+func WithTTLRandomization(shiftPercent uint8) func(*Cache) {
 	return func(c *Cache) {
-		c.maxShiftTTL = maxShiftPercent
+		if shiftPercent > maxTTlShift {
+			c.maxShiftTTL = maxTTlShift
+
+			return
+		}
+
+		c.maxShiftTTL = shiftPercent
 	}
 }
 

--- a/cache_options.go
+++ b/cache_options.go
@@ -1,11 +1,8 @@
 package anycache
 
-// WithTTLRandomization sets max shift of TTL in persent
-// TTL randomization is a technique used to prevent cache stampedes by adding a random shift to the TTL (time-to-live) of cache entries.
-// This helps to distribute the expiration times of cache entries more evenly,
-// reducing the likelihood of multiple entries expiring at the same time and causing a surge in traffic to the underlying data source.
-// The maxShiftPercent parameter specifies the maximum percentage by which the TTL can be shifted randomly. For example,
-// if maxShiftPercent is set to 20, then the TTL of a cache entry can be randomly shifted by up to 20% of its original value.
+// WithTTLRandomization sets the maximum TTL shift percentage.
+// TTL randomization helps prevent cache stampedes by spreading entry expirations over time.
+// Note: the current implementation shifts TTL within roughly ±(maxShiftPercent/2)% of the original TTL.
 func WithTTLRandomization(maxShiftPercent uint8) func(*Cache) {
 	return func(c *Cache) {
 		c.maxShiftTTL = maxShiftPercent

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -35,6 +35,23 @@ func TestWithTTLRandomization(t *testing.T) {
 	assert.NoError(t, err, "Expected to get no error, but got %v", err)
 }
 
+func TestWithWarmUpTTL_MaxTTLShift(t *testing.T) {
+	option := WithTTLRandomization(20)
+	storage := NewMockCacheStorage(t)
+	cache := New(storage, option)
+
+	assert.Equal(t, uint8(20), cache.maxShiftTTL, "Expected TTL randomization factor to be 20 percent, but got %v", cache.maxShiftTTL)
+
+	option = WithTTLRandomization(100)
+	cache = New(storage, option)
+
+	assert.Equal(t, uint8(100), cache.maxShiftTTL, "Expected TTL randomization factor to be 100 percent, but got %v", cache.maxShiftTTL)
+
+	option = WithTTLRandomization(150)
+	cache = New(storage, option)
+	assert.Equal(t, uint8(100), cache.maxShiftTTL, "Expected TTL randomization factor to be capped at 100 percent, but got %v", cache.maxShiftTTL)
+}
+
 func TestWithKeyPrefix(t *testing.T) {
 	option := WithKeyPrefix("testPrefix::")
 

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -19,13 +19,7 @@ func TestWithTTLRandomization(t *testing.T) {
 
 	mockStorage.EXPECT().Get(mock.Anything, "TestKey").Return(nil, ErrKeyNotExists)
 	mockStorage.EXPECT().Set(mock.Anything, "TestKey", []byte("testValue"), mock.MatchedBy(func(ttl time.Duration) bool {
-		if ttl < 90*time.Second || ttl > 110*time.Second {
-			t.Errorf("Expected TTL to be between 90s and 110s, but got %v", ttl)
-			// don't return false here to allow test to continue, otherwise test will stuck
-			return true
-		}
-
-		return true
+		return ttl >= 90*time.Second && ttl <= 110*time.Second
 	})).Return(nil)
 
 	_, err := cache.Cache(t.Context(), "TestKey", func(_ context.Context) ([]byte, error) {

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -1,0 +1,60 @@
+package anycache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWithTTLRandomization(t *testing.T) {
+	option := WithTTLRandomization(10)
+
+	mockStorage := NewMockCacheStorage(t)
+	cache := New(mockStorage, option)
+
+	assert.Equal(t, uint8(10), cache.maxShiftTTL, "Expected TTL randomization factor to be 10 percent, but got %v", cache.maxShiftTTL)
+
+	mockStorage.EXPECT().Get(mock.Anything, "TestKey").Return(nil, ErrKeyNotExists)
+	mockStorage.EXPECT().Set(mock.Anything, "TestKey", []byte("testValue"), mock.MatchedBy(func(ttl time.Duration) bool {
+		if ttl < 90*time.Second || ttl > 110*time.Second {
+			t.Errorf("Expected TTL to be between 90s and 110s, but got %v", ttl)
+			// don't return false here to allow test to continue, otherwise test will stuck
+			return true
+		}
+
+		return true
+	})).Return(nil)
+
+	_, err := cache.Cache(t.Context(), "TestKey", func(_ context.Context) ([]byte, error) {
+		return []byte("testValue"), nil
+	}, WithTTL(100*time.Second))
+
+	assert.NoError(t, err, "Expected to get no error, but got %v", err)
+}
+
+func TestWithKeyPrefix(t *testing.T) {
+	option := WithKeyPrefix("testPrefix::")
+
+	mockStorage := NewMockCacheStorage(t)
+	cache := New(mockStorage, option)
+
+	assert.Equal(t, "testPrefix::", cache.keyPrefix, "Expected key prefix to be 'testPrefix::', but got '%v'", cache.keyPrefix)
+
+	mockStorage.EXPECT().Get(mock.Anything, "testPrefix::TestKey").Return(nil, ErrKeyNotExists)
+	mockStorage.EXPECT().Set(mock.Anything, "testPrefix::TestKey", []byte("testValue"), mock.Anything).Return(nil)
+
+	_, err := cache.Cache(t.Context(), "TestKey", func(_ context.Context) ([]byte, error) {
+		return []byte("testValue"), nil
+	})
+
+	assert.NoError(t, err, "Expected to get no error, but got %v", err)
+
+	mockStorage.EXPECT().Del(mock.Anything, "testPrefix::TestKey").Return(true, nil)
+
+	err = cache.Invalidate(t.Context(), "TestKey")
+
+	assert.NoError(t, err, "Expected to get no error, but got %v", err)
+}

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -163,7 +163,7 @@ func TestInMemoryCacheStorage_Set(t *testing.T) {
 			name:          "Successfully set a value for a key with a TTL and retrieve it before expiration",
 			key:           "key2",
 			value:         []byte("value2"),
-			ttl:           2 * time.Millisecond,
+			ttl:           2 * time.Second,
 			wantErr:       false,
 			waitBeforeGet: time.Millisecond,
 			ableToGet:     true,


### PR DESCRIPTION
This pull request adds new configuration options to the cache system, specifically introducing support for key prefixing and improved TTL randomization, along with corresponding tests. These changes help with cache namespacing, prevent key collisions, and improve cache reliability by spreading out expiration times.

**New cache configuration options:**

* Added `WithKeyPrefix` option to allow setting a default prefix for all cache keys, enabling namespacing and reducing key collisions. The prefix is automatically prepended to keys during cache operations like `Cache` and `Invalidate`. (`anycache.go` [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R40) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R106-R107) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R227-R228); `cache_options.go` [[4]](diffhunk://#diff-affa275e62df18829f1384a753b19561dfe5882b566ec6fb2b8cb908a4e1eed8R1-R29)
* Improved `WithTTLRandomization` option to cap the maximum TTL shift at 100% and moved its implementation to a new file, making TTL randomization safer and more configurable. (`anycache.go` [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L77-L83); `cache_options.go` [[2]](diffhunk://#diff-affa275e62df18829f1384a753b19561dfe5882b566ec6fb2b8cb908a4e1eed8R1-R29)

**Testing enhancements:**

* Added `cache_options_test.go` with tests for both `WithKeyPrefix` and `WithTTLRandomization` to ensure correct behavior, including key prefixing in all cache operations and proper TTL randomization limits. (`cache_options_test.go` [cache_options_test.goR1-R71](diffhunk://#diff-838a1da06a2095f18b1009001455ac70a06f9608de21069fb9900b21cf007555R1-R71))