### PR TITLE
Fix race condition to avoid double warming up of same caching key

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -113,13 +113,13 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 		}()
 
 		var (
-			needWarmUp    bool
-			warmUpLock    bool
-			warmUpStarted bool
+			needWarmUp         bool
+			acquiredWarmUpLock bool
+			warmUpStarted      bool
 		)
 
 		defer func() {
-			if warmUpLock && !warmUpStarted {
+			if acquiredWarmUpLock && !warmUpStarted {
 				c.warmUpLocks.Delete(key)
 			}
 		}()
@@ -128,7 +128,7 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 			var ttl time.Duration
 
 			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
-			warmUpLock = !warmUpLockBusy
+			acquiredWarmUpLock = !warmUpLockBusy
 
 			value, ttl, err = c.Storage.GetWithTTL(c.ctx, key)
 
@@ -147,7 +147,7 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 			return "", err
 		}
 
-		if needWarmUp && warmUpLock {
+		if needWarmUp && acquiredWarmUpLock {
 			c.wg.Go(func() {
 				defer c.warmUpLocks.Delete(key)
 

--- a/anycache.go
+++ b/anycache.go
@@ -33,9 +33,9 @@ type Cache struct {
 	Storage     CacheStorage
 	ctx         context.Context
 	sf          singleflight.Group
-	warmUpSF    singleflight.Group
 	cancelCtx   context.CancelFunc
 	cancel      chan *CacheReuest
+	warmUpLocks sync.Map
 	keyPrefix   string
 	wg          sync.WaitGroup
 	maxShiftTTL uint8
@@ -112,10 +112,23 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 			}
 		}()
 
-		var needWarmUp bool
+		var (
+			needWarmUp    bool
+			warmUpLock    bool
+			warmUpStarted bool
+		)
+
+		defer func() {
+			if warmUpLock && !warmUpStarted {
+				c.warmUpLocks.Delete(key)
+			}
+		}()
 
 		if req.WarmUpTTL > 0 {
 			var ttl time.Duration
+
+			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
+			warmUpLock = !warmUpLockBusy
 
 			value, ttl, err = c.Storage.GetWithTTL(c.ctx, key)
 
@@ -134,17 +147,17 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 			return "", err
 		}
 
-		if needWarmUp {
+		if needWarmUp && warmUpLock {
 			c.wg.Go(func() {
-				_, _, _ = c.warmUpSF.Do(key, func() (any, error) {
-					_, err := c.generateAndSet(ctx, key, req.TTL, generator)
-					if err != nil {
-						slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
-					}
+				defer c.warmUpLocks.Delete(key)
 
-					return nil, nil
-				})
+				_, err := c.generateAndSet(ctx, key, req.TTL, generator)
+				if err != nil {
+					slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
+				}
 			})
+
+			warmUpStarted = true
 		}
 
 		return value, err


### PR DESCRIPTION
This pull request refactors the cache warm-up mechanism to use a `sync.Map` for managing warm-up locks instead of a `singleflight.Group`. The changes improve concurrency control and ensure that only one warm-up per key is in progress at a time, while simplifying the cleanup logic.

**Cache warm-up mechanism improvements:**

* Replaced the `warmUpSF` (`singleflight.Group`) field with a `warmUpLocks` (`sync.Map`) in the `Cache` struct to manage per-key warm-up locks more explicitly.
* Updated the cache warm-up logic in the `Cache` method to use `warmUpLocks` for locking, ensuring only one warm-up goroutine runs per key and cleaning up locks correctly if the warm-up is not started. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L115-R132) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L137-R160)