### PR TITLE
Custom context

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
     - nolintlint
     - prealloc
     - predeclared
-    - revive
     - staticcheck
     - thelper
     - tparallel

--- a/anycache.go
+++ b/anycache.go
@@ -34,7 +34,6 @@ type Cache struct {
 	ctx         context.Context
 	sf          singleflight.Group
 	cancelCtx   context.CancelFunc
-	cancel      chan *CacheReuest
 	warmUpLocks sync.Map
 	keyPrefix   string
 	wg          sync.WaitGroup
@@ -64,7 +63,6 @@ func New(store CacheStorage, opts ...CacheOptions) *Cache {
 		Storage:   store,
 		ctx:       ctx,
 		cancelCtx: cancelCtx,
-		cancel:    make(chan *CacheReuest),
 	}
 
 	for _, opt := range opts {

--- a/anycache.go
+++ b/anycache.go
@@ -149,7 +149,7 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 			c.wg.Go(func() {
 				defer c.warmUpLocks.Delete(key)
 
-				_, err := c.generateAndSet(ctx, key, req.TTL, generator)
+				_, err := c.generateAndSet(c.ctx, key, req.TTL, generator)
 				if err != nil {
 					slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
 				}

--- a/cache_options.go
+++ b/cache_options.go
@@ -30,7 +30,9 @@ func WithKeyPrefix(prefix string) func(*Cache) {
 	}
 }
 
-func WithContext(ctx context.Context) func(*Cache) {
+// WithBaseContext sets the context for cache operations,
+// allowing set base context fot background tasks like warming up cache entries.
+func WithBaseContext(ctx context.Context) func(*Cache) {
 	return func(c *Cache) {
 		c.ctx, c.cancelCtx = context.WithCancel(ctx)
 	}

--- a/cache_options.go
+++ b/cache_options.go
@@ -1,5 +1,7 @@
 package anycache
 
+import "context"
+
 const (
 	maxTTLShift = 100
 )
@@ -25,5 +27,11 @@ func WithTTLRandomization(shiftPercent uint8) func(*Cache) {
 func WithKeyPrefix(prefix string) func(*Cache) {
 	return func(c *Cache) {
 		c.keyPrefix = prefix
+	}
+}
+
+func WithContext(ctx context.Context) func(*Cache) {
+	return func(c *Cache) {
+		c.ctx, c.cancelCtx = context.WithCancel(ctx)
 	}
 }

--- a/cache_options.go
+++ b/cache_options.go
@@ -33,6 +33,10 @@ func WithKeyPrefix(prefix string) func(*Cache) {
 // WithBaseContext sets the base context for cache operations,
 // allowing a custom base context for background tasks such as warming up cache entries.
 func WithBaseContext(ctx context.Context) func(*Cache) {
+	if ctx == nil {
+		panic("base context cannot be nil")
+	}
+
 	return func(c *Cache) {
 		c.ctx, c.cancelCtx = context.WithCancel(ctx)
 	}

--- a/cache_options.go
+++ b/cache_options.go
@@ -30,8 +30,8 @@ func WithKeyPrefix(prefix string) func(*Cache) {
 	}
 }
 
-// WithBaseContext sets the context for cache operations,
-// allowing set base context fot background tasks like warming up cache entries.
+// WithBaseContext sets the base context for cache operations,
+// allowing a custom base context for background tasks such as warming up cache entries.
 func WithBaseContext(ctx context.Context) func(*Cache) {
 	return func(c *Cache) {
 		c.ctx, c.cancelCtx = context.WithCancel(ctx)

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -69,3 +69,17 @@ func TestWithKeyPrefix(t *testing.T) {
 
 	assert.NoError(t, err, "Expected to get no error, but got %v", err)
 }
+
+func TestWithBaseContext(t *testing.T) {
+	baseCtx := context.WithValue(t.Context(), "key", "value")
+	option := WithBaseContext(baseCtx)
+
+	mockStorage := NewMockCacheStorage(t)
+
+	cache := New(mockStorage, option)
+
+	val, ok := cache.ctx.Value("key").(string)
+
+	assert.True(t, ok, "Expected to retrieve a string value from the base context, but got a different type")
+	assert.Equal(t, "value", val, "Expected to retrieve 'value' from the base context, but got '%v'", val)
+}

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -71,7 +71,7 @@ func TestWithKeyPrefix(t *testing.T) {
 }
 
 func TestWithBaseContext(t *testing.T) {
-	baseCtx := context.WithValue(t.Context(), "key", "value")
+	baseCtx := context.WithValue(t.Context(), "key", "value") //nolint:staticcheck // it's fine for test
 	option := WithBaseContext(baseCtx)
 
 	mockStorage := NewMockCacheStorage(t)


### PR DESCRIPTION
This pull request introduces improvements to context management within the cache system, primarily by adding a new option to set a base context for cache operations. It also removes an unused channel from the `Cache` struct and updates the test suite to cover the new functionality.

**Context management improvements:**

* Added a new `WithBaseContext` option in `cache_options.go` that allows users to set a custom base `context.Context` for cache operations, enabling better control over background tasks such as cache warming.
* Updated the `New` function in `anycache.go` to support the new context option by removing the initialization of the unused `cancel` channel.
* Removed the unused `cancel` channel from the `Cache` struct in `anycache.go` to clean up the codebase.

**Testing enhancements:**

* Added a new test `TestWithBaseContext` in `cache_options_test.go` to verify that the base context is correctly set and accessible within the cache.

**Other:**

* Added missing import of the `context` package in `cache_options.go`.