### PR TITLE
Adds Becnchmark test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	docker compose run --rm tests
 
 bench:
-	go test ./tests -run '^$$' -bench . -benchmem
+	docker compose run --rm tests go test ./tests -run '^$$' -bench . -benchmem
 
 lint:
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	docker compose run --rm tests
 
+bench:
+	go test ./tests -run '^$$' -bench . -benchmem
+
 lint:
 	golangci-lint run
 

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -52,7 +52,8 @@ func BenchmarkStorageGet_AllBackends(b *testing.B) {
 			defer cleanup()
 
 			key := benchmarkKey(b, backend.name, "get")
-			require.NoError(b, store.Set(ctx, key, []byte("value"), 30*time.Second))
+			expected := []byte("value")
+			require.NoError(b, store.Set(ctx, key, expected, 30*time.Second))
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -60,7 +61,7 @@ func BenchmarkStorageGet_AllBackends(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				v, err := store.Get(ctx, key)
 				require.NoError(b, err)
-				require.Equal(b, []byte("value"), v)
+				require.Equal(b, expected, v)
 			}
 		})
 	}

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -79,8 +79,9 @@ func BenchmarkAnyCacheHit_AllBackends(b *testing.B) {
 			cache := anycache.New(store)
 			defer func() { _ = cache.Close() }()
 
+			expected := []byte("cached")
 			key := benchmarkKey(b, backend.name, "cache-hit")
-			require.NoError(b, store.Set(ctx, key, []byte("cached"), 30*time.Second))
+			require.NoError(b, store.Set(ctx, key, expected, 30*time.Second))
 
 			generator := func(context.Context) ([]byte, error) {
 				b.Fatal("generator must not be called for cache hit")
@@ -93,7 +94,7 @@ func BenchmarkAnyCacheHit_AllBackends(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
 				require.NoError(b, err)
-				require.Equal(b, []byte("cached"), v)
+				require.Equal(b, expected, v)
 			}
 		})
 	}

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -1,0 +1,173 @@
+package tests
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ksysoev/anycache"
+	"github.com/stretchr/testify/require"
+)
+
+func benchmarkKey(b *testing.B, backend, scope string) string {
+	b.Helper()
+
+	return "bench:" + backend + ":" + scope + ":" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func BenchmarkStorageSet_AllBackends(b *testing.B) {
+	ctx := context.Background()
+
+	for _, backend := range allBackends() {
+		backend := backend
+		b.Run(backend.name, func(b *testing.B) {
+			store, cleanup := backend.new(b)
+			defer cleanup()
+
+			keyPrefix := benchmarkKey(b, backend.name, "set")
+			value := []byte("value")
+
+			const keyspace = 128 // keep bounded to avoid backend-specific eviction behavior
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				key := keyPrefix + ":" + strconv.Itoa(i%keyspace)
+				err := store.Set(ctx, key, value, 30*time.Second)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+func BenchmarkStorageGet_AllBackends(b *testing.B) {
+	ctx := context.Background()
+
+	for _, backend := range allBackends() {
+		backend := backend
+		b.Run(backend.name, func(b *testing.B) {
+			store, cleanup := backend.new(b)
+			defer cleanup()
+
+			key := benchmarkKey(b, backend.name, "get")
+			require.NoError(b, store.Set(ctx, key, []byte("value"), 30*time.Second))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				v, err := store.Get(ctx, key)
+				require.NoError(b, err)
+				require.Equal(b, []byte("value"), v)
+			}
+		})
+	}
+}
+
+func BenchmarkAnyCacheHit_AllBackends(b *testing.B) {
+	ctx := context.Background()
+
+	for _, backend := range allBackends() {
+		backend := backend
+		b.Run(backend.name, func(b *testing.B) {
+			store, cleanup := backend.new(b)
+			defer cleanup()
+
+			cache := anycache.New(store)
+			defer func() { _ = cache.Close() }()
+
+			key := benchmarkKey(b, backend.name, "cache-hit")
+			require.NoError(b, store.Set(ctx, key, []byte("cached"), 30*time.Second))
+
+			generator := func(context.Context) ([]byte, error) {
+				b.Fatal("generator must not be called for cache hit")
+				return nil, nil
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
+				require.NoError(b, err)
+				require.Equal(b, []byte("cached"), v)
+			}
+		})
+	}
+}
+
+func BenchmarkAnyCacheMiss_AllBackends(b *testing.B) {
+	ctx := context.Background()
+
+	for _, backend := range allBackends() {
+		backend := backend
+		b.Run(backend.name, func(b *testing.B) {
+			store, cleanup := backend.new(b)
+			defer cleanup()
+
+			cache := anycache.New(store)
+			defer func() { _ = cache.Close() }()
+
+			baseKey := benchmarkKey(b, backend.name, "cache-miss")
+			generator := func(context.Context) ([]byte, error) {
+				return []byte("generated"), nil
+			}
+
+			const keyspace = 128 // bounded keys, explicitly deleted to force misses
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				key := baseKey + ":" + strconv.Itoa(i%keyspace)
+				_ = store.Del(ctx, key)
+
+				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
+				require.NoError(b, err)
+				require.Equal(b, []byte("generated"), v)
+			}
+		})
+	}
+}
+
+func BenchmarkAnyCacheBalanced80Hit20Miss_AllBackends(b *testing.B) {
+	ctx := context.Background()
+
+	for _, backend := range allBackends() {
+		backend := backend
+		b.Run(backend.name, func(b *testing.B) {
+			store, cleanup := backend.new(b)
+			defer cleanup()
+
+			cache := anycache.New(store)
+			defer func() { _ = cache.Close() }()
+
+			hitKey := benchmarkKey(b, backend.name, "cache-balanced-hit")
+			require.NoError(b, store.Set(ctx, hitKey, []byte("cached"), 30*time.Second))
+
+			missKey := benchmarkKey(b, backend.name, "cache-balanced-miss")
+			generator := func(context.Context) ([]byte, error) {
+				return []byte("generated"), nil
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				key := hitKey
+				expected := []byte("cached")
+				if i%5 == 0 { // 20% misses, 80% hits
+					key = missKey
+					expected = []byte("generated")
+					_ = store.Del(ctx, missKey) // force miss while keeping keyspace bounded
+				}
+
+				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
+				require.NoError(b, err)
+				require.Equal(b, expected, v)
+			}
+		})
+	}
+}

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -146,12 +146,14 @@ func BenchmarkAnyCacheBalanced80Hit20Miss_AllBackends(b *testing.B) {
 			cache := anycache.New(store)
 			defer func() { _ = cache.Close() }()
 
+			expectedCached := []byte("cached")
 			hitKey := benchmarkKey(b, backend.name, "cache-balanced-hit")
-			require.NoError(b, store.Set(ctx, hitKey, []byte("cached"), 30*time.Second))
+			require.NoError(b, store.Set(ctx, hitKey, expectedCached, 30*time.Second))
 
 			missKey := benchmarkKey(b, backend.name, "cache-balanced-miss")
+			expectedGenerated := []byte("generated")
 			generator := func(context.Context) ([]byte, error) {
-				return []byte("generated"), nil
+				return expectedGenerated, nil
 			}
 
 			b.ReportAllocs()
@@ -159,11 +161,13 @@ func BenchmarkAnyCacheBalanced80Hit20Miss_AllBackends(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				key := hitKey
-				expected := []byte("cached")
+				expected := expectedCached
 				if i%5 == 0 { // 20% misses, 80% hits
 					key = missKey
-					expected = []byte("generated")
-					_ = store.Del(ctx, missKey) // force miss while keeping keyspace bounded
+					expected = expectedGenerated
+					if err := store.Del(ctx, missKey); err != nil {
+						b.Fatal(err)
+					}
 				}
 
 				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -165,9 +165,11 @@ func BenchmarkAnyCacheBalanced80Hit20Miss_AllBackends(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				key := hitKey
 				expected := expectedCached
+
 				if i%5 == 0 { // 20% misses, 80% hits
 					key = missKey
 					expected = expectedGenerated
+
 					if err := store.Del(ctx, missKey); err != nil {
 						b.Fatal(err)
 					}

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -113,8 +113,9 @@ func BenchmarkAnyCacheMiss_AllBackends(b *testing.B) {
 			defer func() { _ = cache.Close() }()
 
 			baseKey := benchmarkKey(b, backend.name, "cache-miss")
+			expected := []byte("generated")
 			generator := func(context.Context) ([]byte, error) {
-				return []byte("generated"), nil
+				return expected, nil
 			}
 
 			const keyspace = 128 // bounded keys, explicitly deleted to force misses
@@ -124,11 +125,13 @@ func BenchmarkAnyCacheMiss_AllBackends(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				key := baseKey + ":" + strconv.Itoa(i%keyspace)
-				_ = store.Del(ctx, key)
+				if err := store.Del(ctx, key); err != nil {
+					b.Fatal(err)
+				}
 
 				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
 				require.NoError(b, err)
-				require.Equal(b, []byte("generated"), v)
+				require.Equal(b, expected, v)
 			}
 		})
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type backendFactory struct {
-	new  func(t *testing.T) (anycache.CacheStorage, func())
+	new  func(tb testing.TB) (anycache.CacheStorage, func())
 	name string
 }
 
@@ -32,30 +32,30 @@ func allBackends() []backendFactory {
 	return []backendFactory{
 		{
 			name: "inmemory",
-			new: func(t *testing.T) (anycache.CacheStorage, func()) {
-				t.Helper()
+			new: func(tb testing.TB) (anycache.CacheStorage, func()) {
+				tb.Helper()
 
 				s, err := inmemory.New(256)
-				require.NoError(t, err)
+				require.NoError(tb, err)
 
 				return s, func() { _ = s.Close() }
 			},
 		},
 		{
 			name: "badger",
-			new: func(t *testing.T) (anycache.CacheStorage, func()) {
-				t.Helper()
+			new: func(tb testing.TB) (anycache.CacheStorage, func()) {
+				tb.Helper()
 
-				db, err := badgerdb.Open(badgerdb.DefaultOptions(t.TempDir()).WithLogger(nil))
-				require.NoError(t, err)
+				db, err := badgerdb.Open(badgerdb.DefaultOptions(tb.TempDir()).WithLogger(nil))
+				require.NoError(tb, err)
 
-				return badger.New(db), func() { require.NoError(t, db.Close()) }
+				return badger.New(db), func() { require.NoError(tb, db.Close()) }
 			},
 		},
 		{
 			name: "redis",
-			new: func(t *testing.T) (anycache.CacheStorage, func()) {
-				t.Helper()
+			new: func(tb testing.TB) (anycache.CacheStorage, func()) {
+				tb.Helper()
 
 				client := goredis.NewClient(redisOptions())
 
@@ -65,7 +65,7 @@ func allBackends() []backendFactory {
 				if err := client.Ping(ctx).Err(); err != nil {
 					_ = client.Close()
 
-					t.Skipf("skipping redis backend, unavailable at %s: %v", redisOptions().Addr, err)
+					tb.Skipf("skipping redis backend, unavailable at %s: %v", redisOptions().Addr, err)
 				}
 
 				return redisstore.New(client), func() { _ = client.Close() }
@@ -73,12 +73,12 @@ func allBackends() []backendFactory {
 		},
 		{
 			name: "memcache",
-			new: func(t *testing.T) (anycache.CacheStorage, func()) {
-				t.Helper()
+			new: func(tb testing.TB) (anycache.CacheStorage, func()) {
+				tb.Helper()
 
 				client := memcache.New(memcacheAddr())
 				if err := client.Ping(); err != nil {
-					t.Skipf("skipping memcache backend, unavailable at %s: %v", memcacheAddr(), err)
+					tb.Skipf("skipping memcache backend, unavailable at %s: %v", memcacheAddr(), err)
 				}
 
 				return memcachestore.New(client), func() {}
@@ -86,17 +86,17 @@ func allBackends() []backendFactory {
 		},
 		{
 			name: "layered",
-			new: func(t *testing.T) (anycache.CacheStorage, func()) {
-				t.Helper()
+			new: func(tb testing.TB) (anycache.CacheStorage, func()) {
+				tb.Helper()
 
 				s1, err := inmemory.New(256)
-				require.NoError(t, err)
+				require.NoError(tb, err)
 
 				s2, err := inmemory.New(256)
-				require.NoError(t, err)
+				require.NoError(tb, err)
 
 				s, err := layered.New(s1, s2)
-				require.NoError(t, err)
+				require.NoError(tb, err)
 
 				return s, func() {
 					_ = s1.Close()
@@ -135,10 +135,10 @@ func memcacheAddr() string {
 	return fmt.Sprintf("%s:%s", host, port)
 }
 
-func uniqueKey(t *testing.T, backend string) string {
-	t.Helper()
+func uniqueKey(tb testing.TB, backend string) string {
+	tb.Helper()
 
-	testName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	testName := strings.NewReplacer("/", "_", " ", "_").Replace(tb.Name())
 
 	return fmt.Sprintf("it:%s:%s:%d", backend, testName, time.Now().UnixNano())
 }


### PR DESCRIPTION
This pull request makes improvements to the testing infrastructure and code consistency in the project. The most significant changes are the addition of a benchmark target to the `Makefile` and a refactor of the integration tests to generalize the test interface from `*testing.T` to the more flexible `testing.TB`, which allows for better code reuse and compatibility with both tests and benchmarks.

**Testing infrastructure improvements:**

* Added a `bench` target to the `Makefile` to enable running Go benchmarks with memory allocation statistics.

**Test code refactoring for flexibility and consistency:**

* Refactored all test helper functions and backend factory methods in `tests/integration_test.go` to use `testing.TB` instead of `*testing.T`, improving compatibility with both tests and benchmarks. [[1]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL27-R58) [[2]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL68-R99) [[3]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL138-R141)
* Updated usage of test helper methods (`Helper`, `Skipf`, `NoError`, etc.) and test name retrieval to use the new `testing.TB` parameter throughout the integration tests. [[1]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL27-R58) [[2]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL68-R99) [[3]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL138-R141)