### PR TITLE
Makes TTL as mandatory argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ func main() {
     }
 
     value, err := cache.CacheS(
+        context.Background(),
         "random_number_key", 
         5 * time.Minute, 
         generator, 
-        WithWarmUpTTL(1 * time.Minute)
+        anycache.WithWarmUpTTL(1 * time.Minute)
     )
 
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ func main() {
 
     value, err := cache.CacheS(
         "random_number_key", 
+        5 * time.Minute, 
         generator, 
-        WithTTL(5 * time.Minute), 
         WithWarmUpTTL(1 * time.Minute)
     )
 

--- a/anycache.go
+++ b/anycache.go
@@ -1,4 +1,5 @@
-// Package anycache provide laze caching with posibility to use diffent cache storages
+// Package anycache provide laze caching with posibility to use diffent cache
+// storages
 package anycache
 
 import (
@@ -70,13 +71,6 @@ func New(store CacheStorage, opts ...CacheOptions) *Cache {
 	}
 
 	return &c
-}
-
-// WithTTL sets TTL for cache item
-func WithTTL(ttl time.Duration) CacheItemOptions {
-	return func(req *CacheReuest) {
-		req.TTL = ttl
-	}
 }
 
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up

--- a/anycache.go
+++ b/anycache.go
@@ -80,7 +80,7 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 	}
 }
 
-// Cache caches the result of the generator function for the given key.
+// Cache caches the result of the generator function for the given key, for the specified TTL (time-to-live) duration.
 // If the key already exists in the cache, the cached value is returned.
 // Otherwise, the generator function is called to generate a new value,
 // which is then cached and returned.

--- a/anycache.go
+++ b/anycache.go
@@ -91,10 +91,15 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 // Otherwise, the generator function is called to generate a new value,
 // which is then cached and returned.
 // The function takes an optional list of CacheItemOptions to customize the caching behavior.
-// WithTTL sets TTL for cache item
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
-func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator, opts ...CacheItemOptions) ([]byte, error) {
-	var req CacheReuest
+func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, generator CacheGenerator, opts ...CacheItemOptions) ([]byte, error) {
+	if ttl <= 0 {
+		return nil, errors.New("ttl must be greater than zero")
+	}
+
+	req := CacheReuest{
+		TTL: ttl,
+	}
 
 	for _, opt := range opts {
 		opt(&req)
@@ -179,7 +184,7 @@ func (c *Cache) Cache(ctx context.Context, key string, generator CacheGenerator,
 }
 
 // CacheS is a convenience method that wraps the Cache method to return a string value instead of a byte slice.
-func (c *Cache) CacheS(ctx context.Context, key string, generator CacheGeneratorS, opts ...CacheItemOptions) (string, error) {
+func (c *Cache) CacheS(ctx context.Context, key string, ttl time.Duration, generator CacheGeneratorS, opts ...CacheItemOptions) (string, error) {
 	generatorWrapper := func(ctx context.Context) ([]byte, error) {
 		result, err := generator(ctx)
 		if err != nil {
@@ -189,7 +194,7 @@ func (c *Cache) CacheS(ctx context.Context, key string, generator CacheGenerator
 		return []byte(result), nil
 	}
 
-	val, err := c.Cache(ctx, key, generatorWrapper, opts...)
+	val, err := c.Cache(ctx, key, ttl, generatorWrapper, opts...)
 	if err != nil {
 		return "", err
 	}
@@ -205,7 +210,7 @@ func (c *Cache) CacheS(ctx context.Context, key string, generator CacheGenerator
 // WithTTL sets TTL for cache item
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
 // Returns an error if there was a problem caching or unmarshalling the value.
-func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {
+func (c *Cache) CacheStruct(ctx context.Context, key string, ttl time.Duration, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {
 	generatorWrapper := func(ctx context.Context) ([]byte, error) {
 		val, err := generator(ctx)
 		if err != nil {
@@ -220,7 +225,7 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, generator func(cont
 		return jsonVal, nil
 	}
 
-	val, err := c.Cache(ctx, key, generatorWrapper, opts...)
+	val, err := c.Cache(ctx, key, ttl, generatorWrapper, opts...)
 	if err != nil {
 		return err
 	}

--- a/anycache.go
+++ b/anycache.go
@@ -207,7 +207,7 @@ func (c *Cache) CacheS(ctx context.Context, key string, ttl time.Duration, gener
 // The generator function is called to generate the value if it is not already cached.
 // The result parameter is a pointer to the struct that will be populated with the cached value.
 // The opts parameter is optional and can be used to set additional cache item options.
-// WithTTL sets TTL for cache item
+// The ttl parameter must be greater than zero and controls the cache expiration.
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
 // Returns an error if there was a problem caching or unmarshalling the value.
 func (c *Cache) CacheStruct(ctx context.Context, key string, ttl time.Duration, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -79,7 +79,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
 	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", []byte("newTestValue"), 2*time.Second).Return(nil)
 
-	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", time.Second, getGenerator([]byte("newTestValue"), nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
+	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", 2*time.Second, getGenerator([]byte("newTestValue"), nil), WithWarmUpTTL(1*time.Second))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -23,7 +23,7 @@ func TestCache(t *testing.T) {
 	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return(nil, ErrKeyNotExists).Once()
 	store.EXPECT().Set(mock.Anything, "TestCacheKey", []byte("testValue"), mock.Anything).Return(nil)
 
-	val, err := cache.Cache(t.Context(), "TestCacheKey", getGenerator([]byte("testValue"), nil))
+	val, err := cache.Cache(t.Context(), "TestCacheKey", time.Second, getGenerator([]byte("testValue"), nil))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -32,7 +32,7 @@ func TestCache(t *testing.T) {
 
 	store.EXPECT().Get(mock.Anything, "TestCacheKey").Return([]byte("testValue"), nil)
 
-	val, err = cache.Cache(t.Context(), "TestCacheKey", getGenerator([]byte("testValue1"), nil))
+	val, err = cache.Cache(t.Context(), "TestCacheKey", time.Second, getGenerator([]byte("testValue1"), nil))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -50,7 +50,7 @@ func TestCacheConcurrency(t *testing.T) {
 	store.EXPECT().Set(mock.Anything, "TestCacheConcurrencyKey", mock.Anything, mock.Anything).Return(nil)
 
 	go func(c *Cache, ch chan []byte) {
-		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) ([]byte, error) {
+		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", time.Second, func(_ context.Context) ([]byte, error) {
 			time.Sleep(time.Millisecond)
 			return []byte("testValue"), nil
 		})
@@ -58,7 +58,7 @@ func TestCacheConcurrency(t *testing.T) {
 	}(cache, results)
 
 	go func(c *Cache, ch chan []byte) {
-		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", func(_ context.Context) ([]byte, error) {
+		val, _ := c.Cache(t.Context(), "TestCacheConcurrencyKey", time.Second, func(_ context.Context) ([]byte, error) {
 			time.Sleep(time.Millisecond)
 			return []byte("testValue1"), nil
 		})
@@ -79,7 +79,7 @@ func TestCacheWarmingUp(t *testing.T) {
 	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
 	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", []byte("newTestValue"), 2*time.Second).Return(nil)
 
-	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", getGenerator([]byte("newTestValue"), nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
+	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", time.Second, getGenerator([]byte("newTestValue"), nil), WithTTL(2*time.Second), WithWarmUpTTL(1*time.Second))
 	if err != nil {
 		t.Errorf("Expected to get no error, but got %v", err)
 	}
@@ -117,7 +117,7 @@ func TestCacheJSON(t *testing.T) {
 	var result map[string]string
 
 	// Call the CacheJSON function to cache the test value
-	err := cache.CacheStruct(t.Context(), key, generator, &result)
+	err := cache.CacheStruct(t.Context(), key, time.Second, generator, &result)
 	// Check that the function returned no errors
 	if err != nil {
 		t.Errorf("CacheJSON returned an error: %v", err)
@@ -143,8 +143,7 @@ func TestCancelingRequest(t *testing.T) {
 	// Call the CacheJSON function to cache the test value
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1)
 
-	result, err := cache.Cache(ctx, "TestCancelingRequestKey", generator, WithTTL(2*time.Second))
-
+	result, err := cache.Cache(ctx, "TestCancelingRequestKey", 2*time.Second, generator)
 	// Check that the function returned no errors
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Cache returned unexpected error: %v", err)

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -22,9 +22,9 @@ func TestWithTTLRandomization(t *testing.T) {
 		return ttl >= 90*time.Second && ttl <= 110*time.Second
 	})).Return(nil)
 
-	_, err := cache.Cache(t.Context(), "TestKey", time.Second, func(_ context.Context) ([]byte, error) {
+	_, err := cache.Cache(t.Context(), "TestKey", 100*time.Second, func(_ context.Context) ([]byte, error) {
 		return []byte("testValue"), nil
-	}, WithTTL(100*time.Second))
+	})
 
 	assert.NoError(t, err, "Expected to get no error, but got %v", err)
 }

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -22,7 +22,7 @@ func TestWithTTLRandomization(t *testing.T) {
 		return ttl >= 90*time.Second && ttl <= 110*time.Second
 	})).Return(nil)
 
-	_, err := cache.Cache(t.Context(), "TestKey", func(_ context.Context) ([]byte, error) {
+	_, err := cache.Cache(t.Context(), "TestKey", time.Second, func(_ context.Context) ([]byte, error) {
 		return []byte("testValue"), nil
 	}, WithTTL(100*time.Second))
 
@@ -57,7 +57,7 @@ func TestWithKeyPrefix(t *testing.T) {
 	mockStorage.EXPECT().Get(mock.Anything, "testPrefix::TestKey").Return(nil, ErrKeyNotExists)
 	mockStorage.EXPECT().Set(mock.Anything, "testPrefix::TestKey", []byte("testValue"), mock.Anything).Return(nil)
 
-	_, err := cache.Cache(t.Context(), "TestKey", func(_ context.Context) ([]byte, error) {
+	_, err := cache.Cache(t.Context(), "TestKey", time.Second, func(_ context.Context) ([]byte, error) {
 		return []byte("testValue"), nil
 	})
 

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -92,7 +92,7 @@ func BenchmarkAnyCacheHit_AllBackends(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
+				v, err := cache.Cache(ctx, key, 30*time.Second, generator)
 				require.NoError(b, err)
 				require.Equal(b, expected, v)
 			}
@@ -129,7 +129,7 @@ func BenchmarkAnyCacheMiss_AllBackends(b *testing.B) {
 					b.Fatal(err)
 				}
 
-				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
+				v, err := cache.Cache(ctx, key, 30*time.Second, generator)
 				require.NoError(b, err)
 				require.Equal(b, expected, v)
 			}
@@ -175,7 +175,7 @@ func BenchmarkAnyCacheBalanced80Hit20Miss_AllBackends(b *testing.B) {
 					}
 				}
 
-				v, err := cache.Cache(ctx, key, generator, anycache.WithTTL(30*time.Second))
+				v, err := cache.Cache(ctx, key, 30*time.Second, generator)
 				require.NoError(b, err)
 				require.Equal(b, expected, v)
 			}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -162,11 +162,11 @@ func TestIntegration_CacheMissThenHit_AllBackends(t *testing.T) {
 
 			key := uniqueKey(t, backend.name)
 
-			v1, err := cache.Cache(t.Context(), key, generator, anycache.WithTTL(5*time.Second))
+			v1, err := cache.Cache(t.Context(), key, 5*time.Second, generator)
 			require.NoError(t, err)
 			assert.Equal(t, []byte("value-1"), v1)
 
-			v2, err := cache.Cache(t.Context(), key, generator, anycache.WithTTL(5*time.Second))
+			v2, err := cache.Cache(t.Context(), key, 5*time.Second, generator)
 			require.NoError(t, err)
 			assert.Equal(t, []byte("value-1"), v2)
 			assert.EqualValues(t, 1, calls.Load(), "generator must be called only once for a cache hit")
@@ -193,11 +193,11 @@ func TestIntegration_CacheS_AllBackends(t *testing.T) {
 
 			key := uniqueKey(t, backend.name)
 
-			v1, err := cache.CacheS(t.Context(), key, generator, anycache.WithTTL(5*time.Second))
+			v1, err := cache.CacheS(t.Context(), key, 5*time.Second, generator)
 			require.NoError(t, err)
 			assert.Equal(t, "value", v1)
 
-			v2, err := cache.CacheS(t.Context(), key, generator, anycache.WithTTL(5*time.Second))
+			v2, err := cache.CacheS(t.Context(), key, 5*time.Second, generator)
 			require.NoError(t, err)
 			assert.Equal(t, "value", v2)
 			assert.EqualValues(t, 1, calls.Load())
@@ -231,13 +231,13 @@ func TestIntegration_CacheStruct_AllBackends(t *testing.T) {
 
 			var p1 payload
 
-			err := cache.CacheStruct(t.Context(), key, generator, &p1, anycache.WithTTL(5*time.Second))
+			err := cache.CacheStruct(t.Context(), key, 5*time.Second, generator, &p1)
 			require.NoError(t, err)
 			assert.Equal(t, payload{Name: "john", Count: 1}, p1)
 
 			var p2 payload
 
-			err = cache.CacheStruct(t.Context(), key, generator, &p2, anycache.WithTTL(5*time.Second))
+			err = cache.CacheStruct(t.Context(), key, 5*time.Second, generator, &p2)
 			require.NoError(t, err)
 			assert.Equal(t, payload{Name: "john", Count: 1}, p2)
 			assert.EqualValues(t, 1, calls.Load())
@@ -257,17 +257,17 @@ func TestIntegration_Invalidate_AllBackends(t *testing.T) {
 
 			key := uniqueKey(t, backend.name)
 
-			v1, err := cache.Cache(t.Context(), key, func(context.Context) ([]byte, error) {
+			v1, err := cache.Cache(t.Context(), key, 30*time.Second, func(context.Context) ([]byte, error) {
 				return []byte("v1"), nil
-			}, anycache.WithTTL(30*time.Second))
+			})
 			require.NoError(t, err)
 			assert.Equal(t, []byte("v1"), v1)
 
 			require.NoError(t, cache.Invalidate(t.Context(), key))
 
-			v2, err := cache.Cache(t.Context(), key, func(context.Context) ([]byte, error) {
+			v2, err := cache.Cache(t.Context(), key, 30*time.Second, func(context.Context) ([]byte, error) {
 				return []byte("v2"), nil
-			}, anycache.WithTTL(30*time.Second))
+			})
 			require.NoError(t, err)
 			assert.Equal(t, []byte("v2"), v2)
 		})
@@ -287,9 +287,9 @@ func TestIntegration_KeyPrefix_AllBackends(t *testing.T) {
 			defer func() { _ = cache.Close() }()
 
 			key := "my-key"
-			v, err := cache.Cache(t.Context(), key, func(context.Context) ([]byte, error) {
+			v, err := cache.Cache(t.Context(), key, 10*time.Second, func(context.Context) ([]byte, error) {
 				return []byte("prefixed-value"), nil
-			}, anycache.WithTTL(10*time.Second))
+			})
 			require.NoError(t, err)
 			assert.Equal(t, []byte("prefixed-value"), v)
 
@@ -326,8 +326,8 @@ func TestIntegration_WarmUpTTL_AllBackends(t *testing.T) {
 			v, err := cache.Cache(
 				t.Context(),
 				key,
+				10*time.Second,
 				generator,
-				anycache.WithTTL(10*time.Second),
 				anycache.WithWarmUpTTL(4*time.Second),
 			)
 			require.NoError(t, err)
@@ -383,7 +383,7 @@ func TestIntegration_Singleflight_AllBackends(t *testing.T) {
 				go func() {
 					defer wg.Done()
 
-					v, err := cache.Cache(t.Context(), key, generator, anycache.WithTTL(10*time.Second))
+					v, err := cache.Cache(t.Context(), key, 10*time.Second, generator)
 					if err != nil {
 						errCh <- err
 						return


### PR DESCRIPTION
This pull request refactors the cache API to require the Time-To-Live (TTL) value as a mandatory argument in the primary cache methods, rather than as an optional setting via `WithTTL`. This change makes the TTL explicit and simplifies the function signatures, improving clarity and reducing ambiguity about cache expiration. All usages in tests and benchmarks are updated accordingly.

Key changes:

**Core API Changes:**
- The `Cache`, `CacheS`, and `CacheStruct` methods in `anycache.go` now require `ttl time.Duration` as a mandatory parameter, and return an error if `ttl` is not greater than zero. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L94-R102) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L182-R187) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L208-R213)
- Internally, these methods now set the TTL directly in the cache request, rather than relying on the `WithTTL` option.

**Test Updates:**
- All test cases in `anycache_test.go` and `cache_options_test.go` are updated to pass the TTL as a required argument to cache methods, removing usages of `WithTTL` where applicable. [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL26-R26) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL35-R35) [[3]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL53-R61) [[4]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL82-R82) [[5]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL120-R120) [[6]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL146-R146) [[7]](diffhunk://#diff-838a1da06a2095f18b1009001455ac70a06f9608de21069fb9900b21cf007555L25-R25) [[8]](diffhunk://#diff-838a1da06a2095f18b1009001455ac70a06f9608de21069fb9900b21cf007555L60-R60)

**Benchmark and Integration Test Updates:**
- All benchmarks in `tests/benchmark_test.go` and integration tests in `tests/integration_test.go` are updated to use the new API signature, passing TTL directly and removing redundant `WithTTL` calls. [[1]](diffhunk://#diff-84a9fc79c611f8a5f43af3014fead5978d768dc4808edd6b931eeafdde5e84e0L95-R95) [[2]](diffhunk://#diff-84a9fc79c611f8a5f43af3014fead5978d768dc4808edd6b931eeafdde5e84e0L132-R132) [[3]](diffhunk://#diff-84a9fc79c611f8a5f43af3014fead5978d768dc4808edd6b931eeafdde5e84e0L178-R178) [[4]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL165-R169) [[5]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL196-R200) [[6]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL234-R240) [[7]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL260-R270) [[8]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL290-R292) [[9]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fR329-L330) [[10]](diffhunk://#diff-b65e08ee13b243b12f5823651ac77fe77ed8533be84c2fb475401d70e60f0d7fL386-R386)