### PR TITLE
Adds observervability  hook

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -56,7 +56,7 @@ type Cache struct {
 	maxShiftTTL uint8
 }
 
-type CacheReuest struct {
+type Request struct {
 	MetricHook func(key string, op State, latency time.Duration)
 	TTL        time.Duration
 	WarmUpTTL  time.Duration
@@ -68,7 +68,7 @@ type (
 	CacheOptions    func(*Cache)
 )
 
-type CacheItemOptions func(*CacheReuest)
+type CacheItemOptions func(*Request)
 
 // New creates a new Cache instance with the provided CacheStorage and CacheOptions.
 // WithTTLRandomization sets max shift of TTL in persent
@@ -100,7 +100,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		return nil, errors.New("ttl must be greater than zero")
 	}
 
-	req := CacheReuest{
+	req := Request{
 		TTL:        ttl,
 		MetricHook: c.observer,
 	}

--- a/anycache.go
+++ b/anycache.go
@@ -57,8 +57,9 @@ type Cache struct {
 }
 
 type CacheReuest struct {
-	TTL       time.Duration
-	WarmUpTTL time.Duration
+	MetricHook func(key string, op State, latency time.Duration)
+	TTL        time.Duration
+	WarmUpTTL  time.Duration
 }
 
 type (
@@ -100,23 +101,25 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 	}
 
 	req := CacheReuest{
-		TTL: ttl,
+		TTL:        ttl,
+		MetricHook: c.observer,
 	}
 
 	for _, opt := range opts {
 		opt(&req)
 	}
 
-	key = c.keyPrefix + key
-
 	state := CacheError
 	start := time.Now()
 
-	defer func() {
-		if c.observer != nil {
-			c.observer(key, state, time.Since(start))
-		}
-	}()
+	if req.MetricHook != nil {
+		defer func(key string, start time.Time) {
+			req.MetricHook(key, state, time.Since(start))
+		}(key, start)
+	}
+
+	// appending common key prefix after  Metrics hook, to simplify key parsing for observability
+	key = c.keyPrefix + key
 
 	res := c.sf.DoChan(key, func() (value any, err error) {
 		defer func() {

--- a/anycache.go
+++ b/anycache.go
@@ -19,6 +19,20 @@ const (
 	HundredPercent = 100
 )
 
+type State string
+
+const (
+	CacheHit    State = "hit"
+	CacheMiss   State = "miss"
+	CacheWarmUp State = "warm_up"
+	CacheError  State = "error"
+)
+
+type Result struct {
+	state State
+	data  []byte
+}
+
 var ErrKeyNotExists = errors.New("key does not exist")
 
 // CacheStorage
@@ -35,6 +49,7 @@ type Cache struct {
 	ctx         context.Context
 	sf          singleflight.Group
 	cancelCtx   context.CancelFunc
+	observer    func(key string, op State, latency time.Duration)
 	warmUpLocks sync.Map
 	keyPrefix   string
 	wg          sync.WaitGroup
@@ -94,6 +109,15 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 	req := CacheReuest{
 		TTL: ttl,
 	}
+	var state State
+
+	start := time.Now()
+
+	defer func() {
+		if c.observer != nil {
+			c.observer(key, state, time.Since(start))
+		}
+	}()
 
 	for _, opt := range opts {
 		opt(&req)
@@ -105,11 +129,13 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		defer func() {
 			if r := recover(); r != nil {
 				err = fmt.Errorf("cache.Cache panicked: %v", r)
-				value = ""
+				value = nil
 			}
 		}()
 
 		var (
+			state              State
+			data               []byte
 			needWarmUp         bool
 			acquiredWarmUpLock bool
 			warmUpStarted      bool
@@ -127,21 +153,27 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
 			acquiredWarmUpLock = !warmUpLockBusy
 
-			value, ttl, err = c.Storage.GetWithTTL(c.ctx, key)
+			data, ttl, err = c.Storage.GetWithTTL(c.ctx, key)
 
 			readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
 			if err == nil && readyForWarmUp {
 				needWarmUp = true
 			}
 		} else {
-			value, err = c.Storage.Get(c.ctx, key)
+			data, err = c.Storage.Get(c.ctx, key)
 		}
 
 		switch {
 		case errors.Is(err, ErrKeyNotExists):
-			value, err = c.generateAndSet(ctx, key, req.TTL, generator)
+			state = CacheMiss
+			data, err = c.generateAndSet(ctx, key, req.TTL, generator)
+			if err != nil {
+				return nil, err
+			}
 		case err != nil:
-			return "", err
+			return nil, err
+		default:
+			state = CacheHit
 		}
 
 		if needWarmUp && acquiredWarmUpLock {
@@ -155,9 +187,10 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			})
 
 			warmUpStarted = true
+			state = CacheWarmUp
 		}
 
-		return value, err
+		return &Result{data: data, state: CacheHit}, err
 	})
 
 	select {
@@ -168,12 +201,13 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			return nil, resp.Err
 		}
 
-		val, ok := resp.Val.([]byte)
+		val, ok := resp.Val.(*Result)
 		if !ok {
 			return nil, errors.New("unexpected value type returned from generator")
 		}
 
-		return val, nil
+		state = val.state
+		return val.data, nil
 	}
 }
 

--- a/anycache.go
+++ b/anycache.go
@@ -167,6 +167,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		switch {
 		case errors.Is(err, ErrKeyNotExists):
 			state = CacheMiss
+
 			data, err = c.generateAndSet(ctx, key, req.TTL, generator)
 			if err != nil {
 				return nil, err
@@ -191,7 +192,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			state = CacheWarmUp
 		}
 
-		return &Result{data: data, state: CacheHit}, err
+		return &Result{data: data, state: state}, err
 	})
 
 	select {
@@ -208,6 +209,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		}
 
 		state = val.state
+
 		return val.data, nil
 	}
 }

--- a/anycache.go
+++ b/anycache.go
@@ -110,6 +110,12 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		TTL: ttl,
 	}
 
+	for _, opt := range opts {
+		opt(&req)
+	}
+
+	key = c.keyPrefix + key
+
 	state := CacheError
 	start := time.Now()
 
@@ -118,12 +124,6 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			c.observer(key, state, time.Since(start))
 		}
 	}()
-
-	for _, opt := range opts {
-		opt(&req)
-	}
-
-	key = c.keyPrefix + key
 
 	res := c.sf.DoChan(key, func() (value any, err error) {
 		defer func() {

--- a/anycache.go
+++ b/anycache.go
@@ -114,6 +114,12 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 
 	if req.MetricHook != nil {
 		defer func(key string, start time.Time) {
+			defer func() {
+				if err := recover(); err != nil {
+					slog.Error("MetricHook panicked", "key", key, "error", err)
+				}
+			}()
+
 			req.MetricHook(key, state, time.Since(start))
 		}(key, start)
 	}
@@ -130,7 +136,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		}()
 
 		var (
-			state              State
+			sfState            State
 			data               []byte
 			needWarmUp         bool
 			acquiredWarmUpLock bool
@@ -161,7 +167,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 
 		switch {
 		case errors.Is(err, ErrKeyNotExists):
-			state = CacheMiss
+			sfState = CacheMiss
 
 			data, err = c.generateAndSet(ctx, key, req.TTL, generator)
 			if err != nil {
@@ -170,7 +176,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		case err != nil:
 			return nil, err
 		default:
-			state = CacheHit
+			sfState = CacheHit
 		}
 
 		if needWarmUp && acquiredWarmUpLock {
@@ -184,10 +190,10 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			})
 
 			warmUpStarted = true
-			state = CacheWarmUp
+			sfState = CacheWarmUp
 		}
 
-		return &result{data: data, state: state}, err
+		return &result{data: data, state: sfState}, err
 	})
 
 	select {
@@ -200,7 +206,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 
 		val, ok := resp.Val.(*result)
 		if !ok {
-			return nil, errors.New("unexpected value type returned from generator")
+			return nil, errors.New("unexpected value type returned from cache processing")
 		}
 
 		state = val.state

--- a/anycache.go
+++ b/anycache.go
@@ -28,7 +28,7 @@ const (
 	CacheError  State = "error"
 )
 
-type Result struct {
+type result struct {
 	state State
 	data  []byte
 }
@@ -110,8 +110,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		TTL: ttl,
 	}
 
-	var state State
-
+	state := CacheError
 	start := time.Now()
 
 	defer func() {
@@ -192,7 +191,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			state = CacheWarmUp
 		}
 
-		return &Result{data: data, state: state}, err
+		return &result{data: data, state: state}, err
 	})
 
 	select {
@@ -203,7 +202,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			return nil, resp.Err
 		}
 
-		val, ok := resp.Val.(*Result)
+		val, ok := resp.Val.(*result)
 		if !ok {
 			return nil, errors.New("unexpected value type returned from generator")
 		}

--- a/anycache.go
+++ b/anycache.go
@@ -109,6 +109,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 	req := CacheReuest{
 		TTL: ttl,
 	}
+
 	var state State
 
 	start := time.Now()

--- a/anycache.go
+++ b/anycache.go
@@ -88,13 +88,6 @@ func New(store CacheStorage, opts ...CacheOptions) *Cache {
 	return &c
 }
 
-// WithWarmUpTTL sets TTL threshold for cache item to be warmed up
-func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
-	return func(req *CacheReuest) {
-		req.WarmUpTTL = ttl
-	}
-}
-
 // Cache caches the result of the generator function for the given key, for the specified TTL (time-to-live) duration.
 // If the key already exists in the cache, the cached value is returned.
 // Otherwise, the generator function is called to generate a new value,

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -233,7 +233,7 @@ func TestCacheMetricHook_Error(t *testing.T) {
 	assert.Equal(t, CacheError, observedState)
 }
 
-func TestCacheMetricHook_KeyUsesPrefixedStorageKey(t *testing.T) {
+func TestCacheMetricHook_KeyNotUsesPrefixedStorageKey(t *testing.T) {
 	store := NewMockCacheStorage(t)
 
 	var observedKey string
@@ -245,13 +245,13 @@ func TestCacheMetricHook_KeyUsesPrefixedStorageKey(t *testing.T) {
 		}),
 	)
 
-	store.EXPECT().Get(mock.Anything, "p::metric-prefixed").Return(nil, ErrKeyNotExists)
-	store.EXPECT().Set(mock.Anything, "p::metric-prefixed", []byte("generated"), mock.Anything).Return(nil)
+	store.EXPECT().Get(mock.Anything, "p::metric-key").Return(nil, ErrKeyNotExists)
+	store.EXPECT().Set(mock.Anything, "p::metric-key", []byte("generated"), mock.Anything).Return(nil)
 
-	_, err := cache.Cache(t.Context(), "metric-prefixed", time.Second, getGenerator([]byte("generated"), nil))
+	_, err := cache.Cache(t.Context(), "metric-key", time.Second, getGenerator([]byte("generated"), nil))
 
 	assert.NoError(t, err)
-	assert.Equal(t, "p::metric-prefixed", observedKey)
+	assert.Equal(t, "metric-key", observedKey)
 }
 
 func TestCache_Invalidate(t *testing.T) {

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -73,23 +73,6 @@ func TestCacheConcurrency(t *testing.T) {
 	assert.Equal(t, val1, val2, "Expected to get the same value for both calls, but got '%v' and '%v'", val1, val2)
 }
 
-func TestCacheWarmingUp(t *testing.T) {
-	store := NewMockCacheStorage(t)
-	cache := New(store)
-
-	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
-	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", []byte("newTestValue"), 2*time.Second).Return(nil)
-
-	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", 2*time.Second, getGenerator([]byte("newTestValue"), nil), WithWarmUpTTL(1*time.Second))
-	if err != nil {
-		t.Errorf("Expected to get no error, but got %v", err)
-	}
-
-	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
-
-	time.Sleep(time.Millisecond)
-}
-
 func TestCacheMetricHook_WarmUp(t *testing.T) {
 	store := NewMockCacheStorage(t)
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -89,6 +89,28 @@ func TestCacheWarmingUp(t *testing.T) {
 	time.Sleep(time.Millisecond)
 }
 
+func TestCacheMetricHook_WarmUp(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	var observedState State
+	var observedLatency time.Duration
+
+	cache := New(store, WithMetricHook(func(_ string, op State, latency time.Duration) {
+		observedState = op
+		observedLatency = latency
+	}))
+
+	store.EXPECT().GetWithTTL(mock.Anything, "metric-warmup").Return([]byte("cached"), 500*time.Millisecond, nil)
+	store.EXPECT().Set(mock.Anything, "metric-warmup", []byte("fresh"), 2*time.Second).Return(nil)
+
+	result, err := cache.Cache(t.Context(), "metric-warmup", 2*time.Second, getGenerator([]byte("fresh"), nil), WithWarmUpTTL(time.Second))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cached"), result)
+	assert.Equal(t, CacheWarmUp, observedState)
+	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
+	assert.NoError(t, cache.Close())
+}
+
 func TestRandomizeTTL(t *testing.T) {
 	ttl := randomizeTTL(10, 100*time.Second)
 
@@ -159,6 +181,84 @@ func TestCancelingRequest(t *testing.T) {
 	}
 
 	time.Sleep(time.Millisecond * 10) // watch to finish set on mock
+}
+
+func TestCacheMetricHook_Miss(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	var observedKey string
+	var observedState State
+	var observedLatency time.Duration
+
+	cache := New(store, WithMetricHook(func(key string, op State, latency time.Duration) {
+		observedKey = key
+		observedState = op
+		observedLatency = latency
+	}))
+
+	store.EXPECT().Get(mock.Anything, "metric-miss").Return(nil, ErrKeyNotExists)
+	store.EXPECT().Set(mock.Anything, "metric-miss", []byte("generated"), mock.Anything).Return(nil)
+
+	result, err := cache.Cache(t.Context(), "metric-miss", time.Second, getGenerator([]byte("generated"), nil))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("generated"), result)
+	assert.Equal(t, "metric-miss", observedKey)
+	assert.Equal(t, CacheMiss, observedState)
+	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
+}
+
+func TestCacheMetricHook_Hit(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	var observedState State
+
+	cache := New(store, WithMetricHook(func(_ string, op State, _ time.Duration) {
+		observedState = op
+	}))
+
+	store.EXPECT().Get(mock.Anything, "metric-hit").Return([]byte("cached"), nil)
+
+	result, err := cache.Cache(t.Context(), "metric-hit", time.Second, getGenerator([]byte("generated"), nil))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cached"), result)
+	assert.Equal(t, CacheHit, observedState)
+}
+
+func TestCacheMetricHook_Error(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	var observedState State
+
+	cache := New(store, WithMetricHook(func(_ string, op State, _ time.Duration) {
+		observedState = op
+	}))
+
+	store.EXPECT().Get(mock.Anything, "metric-error").Return(nil, assert.AnError)
+
+	result, err := cache.Cache(t.Context(), "metric-error", time.Second, getGenerator([]byte("generated"), nil))
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, CacheError, observedState)
+}
+
+func TestCacheMetricHook_KeyUsesPrefixedStorageKey(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	var observedKey string
+
+	cache := New(store,
+		WithKeyPrefix("p::"),
+		WithMetricHook(func(key string, _ State, _ time.Duration) {
+			observedKey = key
+		}),
+	)
+
+	store.EXPECT().Get(mock.Anything, "p::metric-prefixed").Return(nil, ErrKeyNotExists)
+	store.EXPECT().Set(mock.Anything, "p::metric-prefixed", []byte("generated"), mock.Anything).Return(nil)
+
+	_, err := cache.Cache(t.Context(), "metric-prefixed", time.Second, getGenerator([]byte("generated"), nil))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "p::metric-prefixed", observedKey)
 }
 
 func TestCache_Invalidate(t *testing.T) {

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+//nolint:unparam // this function is used in tests and always returns the same value and error, so the parameters are not used.
 func getGenerator(val []byte, err error) CacheGenerator {
 	return func(_ context.Context) ([]byte, error) {
 		return val, err
@@ -91,8 +92,11 @@ func TestCacheWarmingUp(t *testing.T) {
 
 func TestCacheMetricHook_WarmUp(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	var observedState State
-	var observedLatency time.Duration
+
+	var (
+		observedState   State
+		observedLatency time.Duration
+	)
 
 	cache := New(store, WithMetricHook(func(_ string, op State, latency time.Duration) {
 		observedState = op
@@ -185,9 +189,12 @@ func TestCancelingRequest(t *testing.T) {
 
 func TestCacheMetricHook_Miss(t *testing.T) {
 	store := NewMockCacheStorage(t)
-	var observedKey string
-	var observedState State
-	var observedLatency time.Duration
+
+	var (
+		observedKey     string
+		observedState   State
+		observedLatency time.Duration
+	)
 
 	cache := New(store, WithMetricHook(func(key string, op State, latency time.Duration) {
 		observedKey = key
@@ -209,6 +216,7 @@ func TestCacheMetricHook_Miss(t *testing.T) {
 
 func TestCacheMetricHook_Hit(t *testing.T) {
 	store := NewMockCacheStorage(t)
+
 	var observedState State
 
 	cache := New(store, WithMetricHook(func(_ string, op State, _ time.Duration) {
@@ -226,6 +234,7 @@ func TestCacheMetricHook_Hit(t *testing.T) {
 
 func TestCacheMetricHook_Error(t *testing.T) {
 	store := NewMockCacheStorage(t)
+
 	var observedState State
 
 	cache := New(store, WithMetricHook(func(_ string, op State, _ time.Duration) {
@@ -243,6 +252,7 @@ func TestCacheMetricHook_Error(t *testing.T) {
 
 func TestCacheMetricHook_KeyUsesPrefixedStorageKey(t *testing.T) {
 	store := NewMockCacheStorage(t)
+
 	var observedKey string
 
 	cache := New(store,

--- a/cache_options.go
+++ b/cache_options.go
@@ -47,6 +47,10 @@ func WithBaseContext(ctx context.Context) func(*Cache) {
 
 // WithMetricHook sets a default hook function to be called for each cache operation, providing metrics such as operation type and latency.
 func WithMetricHook(hook func(key string, op State, latency time.Duration)) func(*Cache) {
+	if hook == nil {
+		panic("metric hook cannot be nil")
+	}
+
 	return func(c *Cache) {
 		c.observer = hook
 	}

--- a/cache_options.go
+++ b/cache_options.go
@@ -1,6 +1,9 @@
 package anycache
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 const (
 	maxTTLShift = 100
@@ -39,5 +42,11 @@ func WithBaseContext(ctx context.Context) func(*Cache) {
 
 	return func(c *Cache) {
 		c.ctx, c.cancelCtx = context.WithCancel(ctx)
+	}
+}
+
+// WithMetricHook sets a hook function to be called for each cache operation, providing metrics such as operation type and latency.
+func WithMetricHook(hook func(key string, op State, latency time.Duration)) func(*Cache) {
+	return func(c *Cache) {
 	}
 }

--- a/cache_options.go
+++ b/cache_options.go
@@ -45,7 +45,7 @@ func WithBaseContext(ctx context.Context) func(*Cache) {
 	}
 }
 
-// WithMetricHook sets a hook function to be called for each cache operation, providing metrics such as operation type and latency.
+// WithMetricHook sets a default hook function to be called for each cache operation, providing metrics such as operation type and latency.
 func WithMetricHook(hook func(key string, op State, latency time.Duration)) func(*Cache) {
 	return func(c *Cache) {
 		c.observer = hook

--- a/cache_options.go
+++ b/cache_options.go
@@ -48,5 +48,6 @@ func WithBaseContext(ctx context.Context) func(*Cache) {
 // WithMetricHook sets a hook function to be called for each cache operation, providing metrics such as operation type and latency.
 func WithMetricHook(hook func(key string, op State, latency time.Duration)) func(*Cache) {
 	return func(c *Cache) {
+		c.observer = hook
 	}
 }

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -88,9 +88,12 @@ func TestWithMetricHook(t *testing.T) {
 	mockStorage := NewMockCacheStorage(t)
 
 	calls := 0
-	var observedKey string
-	var observedState State
-	var observedLatency time.Duration
+
+	var (
+		observedKey     string
+		observedState   State
+		observedLatency time.Duration
+	)
 
 	cache := New(mockStorage, WithMetricHook(func(key string, op State, latency time.Duration) {
 		calls++

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -83,3 +83,32 @@ func TestWithBaseContext(t *testing.T) {
 	assert.True(t, ok, "Expected to retrieve a string value from the base context, but got a different type")
 	assert.Equal(t, "value", val, "Expected to retrieve 'value' from the base context, but got '%v'", val)
 }
+
+func TestWithMetricHook(t *testing.T) {
+	mockStorage := NewMockCacheStorage(t)
+
+	calls := 0
+	var observedKey string
+	var observedState State
+	var observedLatency time.Duration
+
+	cache := New(mockStorage, WithMetricHook(func(key string, op State, latency time.Duration) {
+		calls++
+		observedKey = key
+		observedState = op
+		observedLatency = latency
+	}))
+
+	mockStorage.EXPECT().Get(mock.Anything, "TestKey").Return(nil, ErrKeyNotExists)
+	mockStorage.EXPECT().Set(mock.Anything, "TestKey", []byte("testValue"), mock.Anything).Return(nil)
+
+	_, err := cache.Cache(t.Context(), "TestKey", time.Second, func(_ context.Context) ([]byte, error) {
+		return []byte("testValue"), nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "TestKey", observedKey)
+	assert.Equal(t, CacheMiss, observedState)
+	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
+}

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -115,3 +115,9 @@ func TestWithMetricHook(t *testing.T) {
 	assert.Equal(t, CacheMiss, observedState)
 	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
 }
+
+func TestWithMetricHook_PanicsOnNilHook(t *testing.T) {
+	assert.PanicsWithValue(t, "metric hook cannot be nil", func() {
+		WithMetricHook(nil)
+	})
+}

--- a/request_options.go
+++ b/request_options.go
@@ -4,7 +4,7 @@ import "time"
 
 // WithWarmUpTTL sets TTL threshold for cache item to be warmed up
 func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
-	return func(req *CacheReuest) {
+	return func(req *Request) {
 		req.WarmUpTTL = ttl
 	}
 }
@@ -15,7 +15,7 @@ func WithMetric(hook func(key string, op State, latency time.Duration)) CacheIte
 		panic("metric hook cannot be nil")
 	}
 
-	return func(req *CacheReuest) {
+	return func(req *Request) {
 		req.MetricHook = hook
 	}
 }

--- a/request_options.go
+++ b/request_options.go
@@ -9,7 +9,7 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 	}
 }
 
-// WithMetric override default metric hook for this cache request with function to be called for each cache operation, providing metrics such as operation type and latency.
+// WithMetric overrides the default metric hook for this cache request; the hook is called for each cache operation with its state and latency.
 func WithMetric(hook func(key string, op State, latency time.Duration)) CacheItemOptions {
 	if hook == nil {
 		panic("metric hook cannot be nil")

--- a/request_options.go
+++ b/request_options.go
@@ -1,0 +1,21 @@
+package anycache
+
+import "time"
+
+// WithWarmUpTTL sets TTL threshold for cache item to be warmed up
+func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
+	return func(req *CacheReuest) {
+		req.WarmUpTTL = ttl
+	}
+}
+
+// WithMetric override default metric hook for this cache request with function to be called for each cache operation, providing metrics such as operation type and latency.
+func WithMetric(hook func(key string, op State, latency time.Duration)) CacheItemOptions {
+	if hook == nil {
+		panic("metric hook cannot be nil")
+	}
+
+	return func(req *CacheReuest) {
+		req.MetricHook = hook
+	}
+}

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -1,0 +1,68 @@
+package anycache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	mock "github.com/stretchr/testify/mock"
+)
+
+func TestCacheWarmingUp(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().GetWithTTL(mock.Anything, "TestCacheWarmingUpKey").Return([]byte("testValue"), 500*time.Millisecond, nil)
+	store.EXPECT().Set(mock.Anything, "TestCacheWarmingUpKey", []byte("newTestValue"), 2*time.Second).Return(nil)
+
+	val, err := cache.Cache(t.Context(), "TestCacheWarmingUpKey", 2*time.Second, getGenerator([]byte("newTestValue"), nil), WithWarmUpTTL(1*time.Second))
+	if err != nil {
+		t.Errorf("Expected to get no error, but got %v", err)
+	}
+
+	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
+
+	time.Sleep(time.Millisecond)
+}
+
+func TestWithMetric_OverridesCacheMetricHook(t *testing.T) {
+	store := NewMockCacheStorage(t)
+
+	var (
+		defaultHookCalls int
+		requestHookCalls int
+		observedKey      string
+		observedState    State
+		observedLatency  time.Duration
+	)
+
+	cache := New(store, WithMetricHook(func(_ string, _ State, _ time.Duration) {
+		defaultHookCalls++
+	}))
+
+	requestHook := func(key string, op State, latency time.Duration) {
+		requestHookCalls++
+		observedKey = key
+		observedState = op
+		observedLatency = latency
+	}
+
+	store.EXPECT().Get(mock.Anything, "metric-override").Return(nil, ErrKeyNotExists)
+	store.EXPECT().Set(mock.Anything, "metric-override", []byte("generated"), mock.Anything).Return(nil)
+
+	result, err := cache.Cache(t.Context(), "metric-override", time.Second, getGenerator([]byte("generated"), nil), WithMetric(requestHook))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("generated"), result)
+	assert.Equal(t, 1, requestHookCalls)
+	assert.Equal(t, 0, defaultHookCalls)
+	assert.Equal(t, "metric-override", observedKey)
+	assert.Equal(t, CacheMiss, observedState)
+	assert.GreaterOrEqual(t, observedLatency, time.Duration(0))
+}
+
+func TestWithMetric_PanicsOnNilHook(t *testing.T) {
+	assert.PanicsWithValue(t, "metric hook cannot be nil", func() {
+		WithMetric(nil)
+	})
+}

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -22,7 +22,7 @@ func TestCacheWarmingUp(t *testing.T) {
 
 	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
 
-	time.Sleep(time.Millisecond)
+assert.NoError(t, cache.Close())
 }
 
 func TestWithMetric_OverridesCacheMetricHook(t *testing.T) {

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -22,7 +22,7 @@ func TestCacheWarmingUp(t *testing.T) {
 
 	assert.Equal(t, []byte("testValue"), val, "Expected to get testValue, but got '%v'", val)
 
-assert.NoError(t, cache.Close())
+	assert.NoError(t, cache.Close())
 }
 
 func TestWithMetric_OverridesCacheMetricHook(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new metrics hook mechanism to the cache, enabling observability of cache operations by reporting metrics such as operation type (hit, miss, warm-up, error) and latency. It also refactors how per-request and default metric hooks are set, improves test coverage for these features, and moves request-specific options to a new file for better organization.

**Metrics & Observability Enhancements:**

* Added a `State` type and corresponding constants (`CacheHit`, `CacheMiss`, `CacheWarmUp`, `CacheError`) to represent cache operation outcomes. A new `result` struct now carries both the cache data and its state. (`anycache.go` [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R22-R35) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L130-R179) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R193-R196) [[4]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L171-R214)
* Introduced a default `observer` (metric hook) in the `Cache` struct and a per-request `MetricHook` in `CacheReuest`, both invoked with the cache key, operation state, and latency. Metric hooks are called after each cache operation, with panic protection. (`anycache.go` [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R52-R60) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R105-R140)
* Added the `WithMetricHook` option to set a default metric hook for the cache, and the `WithMetric` option to override the metric hook on a per-request basis. Both panic if a nil hook is provided. (`cache_options.go` [[1]](diffhunk://#diff-affa275e62df18829f1384a753b19561dfe5882b566ec6fb2b8cb908a4e1eed8R47-R57) `request_options.go` [[2]](diffhunk://#diff-13ada4577f84ede0e859377e18c34210d015b1d845fab5f9c451782bb0e35167R1-R21)

**Refactoring & Code Organization:**

* Moved request-specific options (`WithWarmUpTTL`, `WithMetric`) to a new file, `request_options.go`, for better separation of concerns. (`anycache.go` [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L76-L82) `request_options.go` [[2]](diffhunk://#diff-13ada4577f84ede0e859377e18c34210d015b1d845fab5f9c451782bb0e35167R1-R21)

**Testing Improvements:**

* Added and updated tests to cover the new metric hook functionality, including default and per-request hooks, correct state reporting, latency measurement, and error handling. Also verified that the metric hook receives the correct (un-prefixed) key. (`anycache_test.go` [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL75-R98) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bR173-R256) `cache_options_test.go` [[3]](diffhunk://#diff-838a1da06a2095f18b1009001455ac70a06f9608de21069fb9900b21cf007555R86-R123) `request_options_test.go` [[4]](diffhunk://#diff-09f6f7aed72aed48c7b11618921efb7ccdc5daab77ff12ffd90b1f74d2421f06R1-R68)

**Backward Compatibility:**

* The public API for setting warm-up TTL and cache options remains available, but per-request options are now in a dedicated file. (`anycache.go` [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L76-L82) `request_options.go` [[2]](diffhunk://#diff-13ada4577f84ede0e859377e18c34210d015b1d845fab5f9c451782bb0e35167R1-R21)

These changes significantly improve the observability and flexibility of the cache, making it easier to monitor and analyze cache behavior in production systems.