### PR TITLE
Adds possibility to decouple cache request context from incoming request

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -112,12 +112,6 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 	}
 
 	req.ctx = ctx
-	if req.Timeout > 0 {
-		var cancel context.CancelFunc
-
-		req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
-		defer cancel()
-	}
 
 	state := CacheError
 	start := time.Now()
@@ -145,6 +139,12 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			}
 		}()
 
+		if req.Timeout > 0 {
+			var cancel context.CancelFunc
+
+			req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+			defer cancel()
+		}
 		var (
 			sfState            State
 			data               []byte

--- a/anycache.go
+++ b/anycache.go
@@ -111,6 +111,14 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		opt(&req)
 	}
 
+	req.ctx = ctx
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+
+		req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+		defer cancel()
+	}
+
 	state := CacheError
 	start := time.Now()
 

--- a/anycache.go
+++ b/anycache.go
@@ -57,9 +57,11 @@ type Cache struct {
 }
 
 type Request struct {
+	ctx        context.Context
 	MetricHook func(key string, op State, latency time.Duration)
 	TTL        time.Duration
 	WarmUpTTL  time.Duration
+	Timeout    time.Duration
 }
 
 type (
@@ -155,21 +157,21 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
 			acquiredWarmUpLock = !warmUpLockBusy
 
-			data, ttl, err = c.Storage.GetWithTTL(c.ctx, key)
+			data, ttl, err = c.Storage.GetWithTTL(req.ctx, key)
 
 			readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
 			if err == nil && readyForWarmUp {
 				needWarmUp = true
 			}
 		} else {
-			data, err = c.Storage.Get(c.ctx, key)
+			data, err = c.Storage.Get(req.ctx, key)
 		}
 
 		switch {
 		case errors.Is(err, ErrKeyNotExists):
 			sfState = CacheMiss
 
-			data, err = c.generateAndSet(ctx, key, req.TTL, generator)
+			data, err = c.generateAndSet(req.ctx, key, req.TTL, generator)
 			if err != nil {
 				return nil, err
 			}
@@ -183,7 +185,16 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			c.wg.Go(func() {
 				defer c.warmUpLocks.Delete(key)
 
-				_, err := c.generateAndSet(c.ctx, key, req.TTL, generator)
+				ctx := c.ctx
+
+				if req.Timeout > 0 {
+					var cancel context.CancelFunc
+
+					ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+					defer cancel()
+				}
+
+				_, err := c.generateAndSet(ctx, key, req.TTL, generator)
 				if err != nil {
 					slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
 				}

--- a/anycache.go
+++ b/anycache.go
@@ -145,6 +145,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
 			defer cancel()
 		}
+
 		var (
 			sfState            State
 			data               []byte

--- a/anycache.go
+++ b/anycache.go
@@ -199,7 +199,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 				if req.Timeout > 0 {
 					var cancel context.CancelFunc
 
-					ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+					ctx, cancel = context.WithTimeout(ctx, req.Timeout)
 					defer cancel()
 				}
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -3,6 +3,7 @@ package anycache
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -168,6 +169,201 @@ func TestCancelingRequest(t *testing.T) {
 	}
 
 	time.Sleep(time.Millisecond * 10) // watch to finish set on mock
+}
+
+func TestCache_DefaultContextForwarding_NoWithTimeout(t *testing.T) {
+	type ctxKey string
+
+	const key ctxKey = "request-id"
+
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	ctx := context.WithValue(context.Background(), key, "req-123")
+
+	store.EXPECT().Get(mock.Anything, "ctx-forwarding").RunAndReturn(func(gotCtx context.Context, _ string) ([]byte, error) {
+		assert.Equal(t, "req-123", gotCtx.Value(key))
+		return nil, ErrKeyNotExists
+	})
+	store.EXPECT().Set(mock.Anything, "ctx-forwarding", []byte("generated"), mock.Anything).RunAndReturn(func(gotCtx context.Context, _ string, _ []byte, _ time.Duration) error {
+		assert.Equal(t, "req-123", gotCtx.Value(key))
+		return nil
+	})
+
+	result, err := cache.Cache(ctx, "ctx-forwarding", time.Second, func(gotCtx context.Context) ([]byte, error) {
+		assert.Equal(t, "req-123", gotCtx.Value(key))
+		return []byte("generated"), nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("generated"), result)
+}
+
+func TestCache_DefaultContextCancellationPropagation_NoWithTimeout(t *testing.T) {
+	t.Run("deadline context", func(t *testing.T) {
+		store := NewMockCacheStorage(t)
+		cache := New(store)
+
+		store.EXPECT().Get(mock.Anything, "ctx-deadline").Return(nil, ErrKeyNotExists)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		generatorStarted := make(chan struct{})
+
+		result, err := cache.Cache(ctx, "ctx-deadline", time.Second, func(genCtx context.Context) ([]byte, error) {
+			close(generatorStarted)
+			<-genCtx.Done()
+			return nil, genCtx.Err()
+		})
+
+		select {
+		case <-generatorStarted:
+		case <-time.After(time.Second):
+			t.Fatal("generator did not start")
+		}
+
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("manual cancel context", func(t *testing.T) {
+		store := NewMockCacheStorage(t)
+		cache := New(store)
+
+		store.EXPECT().Get(mock.Anything, "ctx-cancel").Return(nil, ErrKeyNotExists)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result, err := cache.Cache(ctx, "ctx-cancel", time.Second, func(genCtx context.Context) ([]byte, error) {
+			<-genCtx.Done()
+			return nil, genCtx.Err()
+		})
+
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestCache_WithTimeout_DecouplesWorkFromCallerContext(t *testing.T) {
+	type ctxKey string
+
+	const key ctxKey = "request-id"
+
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	generatorStarted := make(chan struct{})
+	releaseGenerator := make(chan struct{})
+	setCalled := make(chan struct{})
+
+	store.EXPECT().Get(mock.Anything, "timeout-decouple").Return(nil, ErrKeyNotExists).Once()
+	store.EXPECT().Set(mock.Anything, "timeout-decouple", []byte("generated"), mock.Anything).RunAndReturn(func(setCtx context.Context, _ string, _ []byte, _ time.Duration) error {
+		assert.Nil(t, setCtx.Value(key), "expected internal context to be decoupled from caller values when WithTimeout is used")
+		close(setCalled)
+		return nil
+	}).Once()
+
+	callerCtx, cancelCaller := context.WithCancel(context.WithValue(context.Background(), key, "caller-value"))
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := cache.Cache(callerCtx, "timeout-decouple", time.Second, func(genCtx context.Context) ([]byte, error) {
+			assert.Nil(t, genCtx.Value(key), "expected generator context to be decoupled from caller values when WithTimeout is used")
+			close(generatorStarted)
+			<-releaseGenerator
+			return []byte("generated"), nil
+		}, WithTimeout(300*time.Millisecond))
+		errCh <- err
+	}()
+
+	select {
+	case <-generatorStarted:
+	case <-time.After(time.Second):
+		t.Fatal("generator did not start")
+	}
+
+	cancelCaller()
+	close(releaseGenerator)
+
+	select {
+	case <-setCalled:
+	case <-time.After(time.Second):
+		t.Fatal("storage set was not called after caller cancellation")
+	}
+
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("cache call did not return")
+	}
+}
+
+func TestCache_WithTimeout_SingleflightContinuesAfterInitiatorCancel(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	var generatorCalls atomic.Int32
+	generatorStarted := make(chan struct{})
+	releaseGenerator := make(chan struct{})
+
+	store.EXPECT().Get(mock.Anything, "timeout-singleflight").Return(nil, ErrKeyNotExists).Once()
+	store.EXPECT().Set(mock.Anything, "timeout-singleflight", []byte("generated"), mock.Anything).Return(nil).Once()
+
+	initiatorCtx, cancelInitiator := context.WithCancel(context.Background())
+	initiatorErrCh := make(chan error, 1)
+	waiterValCh := make(chan []byte, 1)
+	waiterErrCh := make(chan error, 1)
+
+	go func() {
+		_, err := cache.Cache(initiatorCtx, "timeout-singleflight", time.Second, func(_ context.Context) ([]byte, error) {
+			generatorCalls.Add(1)
+			close(generatorStarted)
+			<-releaseGenerator
+			return []byte("generated"), nil
+		}, WithTimeout(300*time.Millisecond))
+		initiatorErrCh <- err
+	}()
+
+	select {
+	case <-generatorStarted:
+	case <-time.After(time.Second):
+		t.Fatal("generator did not start")
+	}
+
+	go func() {
+		val, err := cache.Cache(t.Context(), "timeout-singleflight", time.Second, getGenerator([]byte("unused"), nil), WithTimeout(300*time.Millisecond))
+		waiterValCh <- val
+		waiterErrCh <- err
+	}()
+
+	cancelInitiator()
+	close(releaseGenerator)
+
+	select {
+	case err := <-initiatorErrCh:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("initiator call did not return")
+	}
+
+	select {
+	case err := <-waiterErrCh:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("waiter call did not return")
+	}
+
+	select {
+	case val := <-waiterValCh:
+		assert.Equal(t, []byte("generated"), val)
+	case <-time.After(time.Second):
+		t.Fatal("waiter value was not returned")
+	}
+
+	assert.Equal(t, int32(1), generatorCalls.Load(), "expected shared generation to run once")
 }
 
 func TestCacheMetricHook_Miss(t *testing.T) {

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -214,6 +214,7 @@ func TestCache_DefaultContextCancellationPropagation_NoWithTimeout(t *testing.T)
 		result, err := cache.Cache(ctx, "ctx-deadline", time.Second, func(genCtx context.Context) ([]byte, error) {
 			close(generatorStarted)
 			<-genCtx.Done()
+
 			return nil, genCtx.Err()
 		})
 
@@ -262,6 +263,7 @@ func TestCache_WithTimeout_DecouplesWorkFromCallerContext(t *testing.T) {
 	store.EXPECT().Set(mock.Anything, "timeout-decouple", []byte("generated"), mock.Anything).RunAndReturn(func(setCtx context.Context, _ string, _ []byte, _ time.Duration) error {
 		assert.Nil(t, setCtx.Value(key), "expected internal context to be decoupled from caller values when WithTimeout is used")
 		close(setCalled)
+
 		return nil
 	}).Once()
 
@@ -273,6 +275,7 @@ func TestCache_WithTimeout_DecouplesWorkFromCallerContext(t *testing.T) {
 			assert.Nil(t, genCtx.Value(key), "expected generator context to be decoupled from caller values when WithTimeout is used")
 			close(generatorStarted)
 			<-releaseGenerator
+
 			return []byte("generated"), nil
 		}, WithTimeout(300*time.Millisecond))
 		errCh <- err
@@ -306,6 +309,7 @@ func TestCache_WithTimeout_SingleflightContinuesAfterInitiatorCancel(t *testing.
 	cache := New(store)
 
 	var generatorCalls atomic.Int32
+
 	generatorStarted := make(chan struct{})
 	releaseGenerator := make(chan struct{})
 
@@ -322,6 +326,7 @@ func TestCache_WithTimeout_SingleflightContinuesAfterInitiatorCancel(t *testing.
 			generatorCalls.Add(1)
 			close(generatorStarted)
 			<-releaseGenerator
+
 			return []byte("generated"), nil
 		}, WithTimeout(300*time.Millisecond))
 		initiatorErrCh <- err
@@ -336,6 +341,7 @@ func TestCache_WithTimeout_SingleflightContinuesAfterInitiatorCancel(t *testing.
 	go func() {
 		val, err := cache.Cache(t.Context(), "timeout-singleflight", time.Second, getGenerator([]byte("unused"), nil), WithTimeout(300*time.Millisecond))
 		waiterValCh <- val
+
 		waiterErrCh <- err
 	}()
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -232,10 +232,10 @@ func TestCache_DefaultContextCancellationPropagation_NoWithTimeout(t *testing.T)
 		store := NewMockCacheStorage(t)
 		cache := New(store)
 
-		store.EXPECT().Get(mock.Anything, "ctx-cancel").Return(nil, ErrKeyNotExists)
-
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
+
+		store.EXPECT().Get(mock.Anything, "ctx-cancel").Maybe().Return(nil, context.Canceled)
 
 		result, err := cache.Cache(ctx, "ctx-cancel", time.Second, func(genCtx context.Context) ([]byte, error) {
 			<-genCtx.Done()

--- a/cache_options.go
+++ b/cache_options.go
@@ -45,7 +45,8 @@ func WithBaseContext(ctx context.Context) func(*Cache) {
 	}
 }
 
-// WithMetricHook sets a default hook function to be called for each cache operation, providing metrics such as operation type and latency.
+// WithMetricHookksets a default hook function to be called for each cache operation,
+// providing metrics such as operation type and latency.
 func WithMetricHook(hook func(key string, op State, latency time.Duration)) func(*Cache) {
 	if hook == nil {
 		panic("metric hook cannot be nil")

--- a/cache_options.go
+++ b/cache_options.go
@@ -45,7 +45,7 @@ func WithBaseContext(ctx context.Context) func(*Cache) {
 	}
 }
 
-// WithMetricHookksets a default hook function to be called for each cache operation,
+// WithMetricHook sets a default hook function to be called for each cache operation,
 // providing metrics such as operation type and latency.
 func WithMetricHook(hook func(key string, op State, latency time.Duration)) func(*Cache) {
 	if hook == nil {

--- a/request_options.go
+++ b/request_options.go
@@ -9,7 +9,8 @@ func WithWarmUpTTL(ttl time.Duration) CacheItemOptions {
 	}
 }
 
-// WithMetric overrides the default metric hook for this cache request; the hook is called for each cache operation with its state and latency.
+// WithMetric overrides the default metric hook for this cache request;
+// the hook is called for each cache operation with its state and latency.
 func WithMetric(hook func(key string, op State, latency time.Duration)) CacheItemOptions {
 	if hook == nil {
 		panic("metric hook cannot be nil")
@@ -17,5 +18,14 @@ func WithMetric(hook func(key string, op State, latency time.Duration)) CacheIte
 
 	return func(req *Request) {
 		req.MetricHook = hook
+	}
+}
+
+// WithTimeout decouples cache request processing from incoming context,
+// that request cancelations will not affect concurent request waiting for same key to be generated.
+// It sets a timeout for the cache request, after which the request will be canceled if not completed.
+func WithTimeout(timeout time.Duration) CacheItemOptions {
+	return func(req *Request) {
+		req.Timeout = timeout
 	}
 }

--- a/request_options.go
+++ b/request_options.go
@@ -21,9 +21,9 @@ func WithMetric(hook func(key string, op State, latency time.Duration)) CacheIte
 	}
 }
 
-// WithTimeout decouples cache request processing from the incoming context so that
-// cancellations on the incoming request do not affect other callers waiting for the same key to be generated.
-// It sets a timeout for the cache request, after which the request will be canceled if not completed.
+// WithTimeout sets a timeout for the internal cache work (storage + generation).
+// When set, the internal work runs on the cache base context (see WithBaseContext),
+// so caller cancellation and context values are not propagated to storage/generator.
 func WithTimeout(timeout time.Duration) CacheItemOptions {
 	return func(req *Request) {
 		req.Timeout = timeout

--- a/request_options.go
+++ b/request_options.go
@@ -21,8 +21,8 @@ func WithMetric(hook func(key string, op State, latency time.Duration)) CacheIte
 	}
 }
 
-// WithTimeout decouples cache request processing from incoming context,
-// that request cancelations will not affect concurent request waiting for same key to be generated.
+// WithTimeout decouples cache request processing from the incoming context so that
+// cancellations on the incoming request do not affect other callers waiting for the same key to be generated.
 // It sets a timeout for the cache request, after which the request will be canceled if not completed.
 func WithTimeout(timeout time.Duration) CacheItemOptions {
 	return func(req *Request) {

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -66,3 +66,20 @@ func TestWithMetric_PanicsOnNilHook(t *testing.T) {
 		WithMetric(nil)
 	})
 }
+
+func TestWithTimeout_SetsRequestTimeout(t *testing.T) {
+	req := &Request{}
+	timeout := 250 * time.Millisecond
+
+	WithTimeout(timeout)(req)
+
+	assert.Equal(t, timeout, req.Timeout)
+}
+
+func TestWithTimeout_ZeroDuration(t *testing.T) {
+	req := &Request{}
+
+	WithTimeout(0)(req)
+
+	assert.Zero(t, req.Timeout)
+}


### PR DESCRIPTION
This pull request enhances the cache request handling by introducing per-request timeout support and improving context management. It also includes minor documentation updates for clarity.

### Per-request timeout support

* Added a `Timeout` field to the `Request` struct and implemented the `WithTimeout` option, allowing callers to specify a timeout for individual cache requests. This ensures that long-running cache operations are canceled if they exceed the specified duration. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R60-R64) [[2]](diffhunk://#diff-13ada4577f84ede0e859377e18c34210d015b1d845fab5f9c451782bb0e35167R23-R31)
* Updated the cache warm-up logic to respect the per-request timeout by wrapping the context with `context.WithTimeout` when a timeout is set.

### Context management improvements

* Modified all cache storage and generation calls to use the request-specific context (`req.ctx`) instead of the global cache context, ensuring proper cancellation and isolation for each request.

### Documentation updates

* Improved comments for option functions in `cache_options.go` and `request_options.go` for better clarity and consistency. [[1]](diffhunk://#diff-affa275e62df18829f1384a753b19561dfe5882b566ec6fb2b8cb908a4e1eed8L48-R49) [[2]](diffhunk://#diff-13ada4577f84ede0e859377e18c34210d015b1d845fab5f9c451782bb0e35167L12-R13)