### PR TITLE
Refactors code to reduce cyclomatic complexity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,8 @@ linters:
       allow-first-in-block: true
       allow-whole-block: false
       branch-max-lines: 2
+    gocyclo:
+      min-complexity: 15
   exclusions:
     generated: lax
     presets:

--- a/anycache.go
+++ b/anycache.go
@@ -131,90 +131,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 	// appending common key prefix after  Metrics hook, to simplify key parsing for observability
 	key = c.keyPrefix + key
 
-	res := c.sf.DoChan(key, func() (value any, err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("cache.Cache panicked: %v", r)
-				value = nil
-			}
-		}()
-
-		if req.Timeout > 0 {
-			var cancel context.CancelFunc
-
-			req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
-			defer cancel()
-		}
-
-		var (
-			sfState            State
-			data               []byte
-			needWarmUp         bool
-			acquiredWarmUpLock bool
-			warmUpStarted      bool
-		)
-
-		defer func() {
-			if acquiredWarmUpLock && !warmUpStarted {
-				c.warmUpLocks.Delete(key)
-			}
-		}()
-
-		if req.WarmUpTTL > 0 {
-			var ttl time.Duration
-
-			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
-			acquiredWarmUpLock = !warmUpLockBusy
-
-			data, ttl, err = c.Storage.GetWithTTL(req.ctx, key)
-
-			readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
-			if err == nil && readyForWarmUp {
-				needWarmUp = true
-			}
-		} else {
-			data, err = c.Storage.Get(req.ctx, key)
-		}
-
-		switch {
-		case errors.Is(err, ErrKeyNotExists):
-			sfState = CacheMiss
-
-			data, err = c.generateAndSet(req.ctx, key, req.TTL, generator)
-			if err != nil {
-				return nil, err
-			}
-		case err != nil:
-			return nil, err
-		default:
-			sfState = CacheHit
-		}
-
-		if needWarmUp && acquiredWarmUpLock {
-			c.wg.Go(func() {
-				defer c.warmUpLocks.Delete(key)
-
-				ctx := c.ctx
-
-				if req.Timeout > 0 {
-					var cancel context.CancelFunc
-
-					ctx, cancel = context.WithTimeout(ctx, req.Timeout)
-					defer cancel()
-				}
-
-				_, err := c.generateAndSet(ctx, key, req.TTL, generator)
-				if err != nil {
-					slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
-				}
-			})
-
-			warmUpStarted = true
-			sfState = CacheWarmUp
-		}
-
-		return &result{data: data, state: sfState}, err
-	})
+	res := c.processRequest(key, generator, req)
 
 	select {
 	case <-ctx.Done():
@@ -344,4 +261,95 @@ func (c *Cache) Close() error {
 	c.wg.Wait()
 
 	return nil
+}
+
+func (c *Cache) processRequest(key string, generator CacheGenerator, req Request) <-chan singleflight.Result {
+	return c.sf.DoChan(key, func() (value any, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("cache.Cache panicked: %v", r)
+				value = nil
+			}
+		}()
+
+		if req.Timeout > 0 {
+			var cancel context.CancelFunc
+
+			req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+			defer cancel()
+		}
+
+		var (
+			sfState            State
+			data               []byte
+			needWarmUp         bool
+			acquiredWarmUpLock bool
+			warmUpStarted      bool
+		)
+
+		defer func() {
+			if acquiredWarmUpLock && !warmUpStarted {
+				c.warmUpLocks.Delete(key)
+			}
+		}()
+
+		if req.WarmUpTTL > 0 {
+			var ttl time.Duration
+
+			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
+			acquiredWarmUpLock = !warmUpLockBusy
+
+			data, ttl, err = c.Storage.GetWithTTL(req.ctx, key)
+
+			readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
+			if err == nil && readyForWarmUp {
+				needWarmUp = true
+			}
+		} else {
+			data, err = c.Storage.Get(req.ctx, key)
+		}
+
+		switch {
+		case errors.Is(err, ErrKeyNotExists):
+			sfState = CacheMiss
+
+			data, err = c.generateAndSet(req.ctx, key, req.TTL, generator)
+			if err != nil {
+				return nil, err
+			}
+		case err != nil:
+			return nil, err
+		default:
+			sfState = CacheHit
+		}
+
+		if needWarmUp && acquiredWarmUpLock {
+			c.startWarmUp(key, generator, req)
+
+			warmUpStarted = true
+			sfState = CacheWarmUp
+		}
+
+		return &result{data: data, state: sfState}, err
+	})
+}
+
+func (c *Cache) startWarmUp(key string, generator CacheGenerator, req Request) {
+	c.wg.Go(func() {
+		defer c.warmUpLocks.Delete(key)
+
+		ctx := c.ctx
+
+		if req.Timeout > 0 {
+			var cancel context.CancelFunc
+
+			ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+			defer cancel()
+		}
+
+		_, err := c.generateAndSet(ctx, key, req.TTL, generator)
+		if err != nil {
+			slog.Warn("Failed to warm up cache for key", "key", key, "error", err)
+		}
+	})
 }

--- a/anycache.go
+++ b/anycache.go
@@ -263,6 +263,7 @@ func (c *Cache) Close() error {
 	return nil
 }
 
+// processRequest processes a cache request for the given key using the provided generator function and request options.
 func (c *Cache) processRequest(key string, generator CacheGenerator, req Request) <-chan singleflight.Result {
 	return c.sf.DoChan(key, func() (value any, err error) {
 		defer func() {
@@ -334,6 +335,8 @@ func (c *Cache) processRequest(key string, generator CacheGenerator, req Request
 	})
 }
 
+// startWarmUp starts a background goroutine to warm up the cache for the given key
+// using the provided generator function and request options.
 func (c *Cache) startWarmUp(key string, generator CacheGenerator, req Request) {
 	c.wg.Go(func() {
 		defer c.warmUpLocks.Delete(key)

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -514,3 +514,66 @@ func TestCache_Invalidate(t *testing.T) {
 		})
 	}
 }
+
+func TestCache_GeneratorPanicRecovered(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().Get(mock.Anything, "panic-recovery").Return(nil, ErrKeyNotExists).Once()
+
+	result, err := cache.Cache(t.Context(), "panic-recovery", time.Second, func(_ context.Context) ([]byte, error) {
+		panic("boom")
+	})
+
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cache.Cache panicked")
+}
+
+func TestCache_WarmUpLockReleasedWhenWarmUpNotNeeded(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().GetWithTTL(mock.Anything, "warmup-lock-release").Return([]byte("cached"), 5*time.Second, nil).Once()
+
+	result, err := cache.Cache(t.Context(), "warmup-lock-release", 10*time.Second, getGenerator([]byte("fresh"), nil), WithWarmUpTTL(time.Second))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cached"), result)
+
+	_, exists := cache.warmUpLocks.Load("warmup-lock-release")
+	assert.False(t, exists, "warm up lock should be released when warm up is not started")
+}
+
+func TestCache_WarmUpHonorsTimeout(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().GetWithTTL(mock.Anything, "warmup-timeout").Return([]byte("cached"), 200*time.Millisecond, nil).Once()
+	store.EXPECT().Set(mock.Anything, "warmup-timeout", []byte("fresh"), mock.Anything).RunAndReturn(func(ctx context.Context, _ string, _ []byte, _ time.Duration) error {
+		_, ok := ctx.Deadline()
+		assert.True(t, ok, "expected warm up context with deadline")
+
+		return nil
+	}).Once()
+
+	result, err := cache.Cache(t.Context(), "warmup-timeout", 3*time.Second, getGenerator([]byte("fresh"), nil), WithWarmUpTTL(time.Second), WithTimeout(50*time.Millisecond))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cached"), result)
+	assert.NoError(t, cache.Close())
+}
+
+func TestCache_WarmUpSetErrorIsHandled(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().GetWithTTL(mock.Anything, "warmup-set-error").Return([]byte("cached"), 200*time.Millisecond, nil).Once()
+	store.EXPECT().Set(mock.Anything, "warmup-set-error", []byte("fresh"), mock.Anything).Return(assert.AnError).Once()
+
+	result, err := cache.Cache(t.Context(), "warmup-set-error", 2*time.Second, getGenerator([]byte("fresh"), nil), WithWarmUpTTL(time.Second))
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cached"), result)
+	assert.NoError(t, cache.Close())
+}

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -328,13 +329,10 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 				t.Helper()
 
 				s, err := New(10)
-				if err != nil {
-					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
-				}
+				require.NoError(t, err, "Failed to create InMemoryCacheStorage: %v", err)
 
-				if err = s.Set(t.Context(), "key1", []byte("value1"), time.Millisecond); err != nil {
-					t.Fatalf("Failed to set key1: %v", err)
-				}
+				err = s.Set(t.Context(), "key1", []byte("value1"), time.Millisecond)
+				require.NoError(t, err, "Failed to set key1: %v", err)
 
 				return s
 			},
@@ -349,13 +347,10 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 				t.Helper()
 
 				s, err := New(10)
-				if err != nil {
-					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
-				}
+				require.NoError(t, err, "Failed to create InMemoryCacheStorage: %v", err)
 
-				if err = s.Set(t.Context(), "key1", []byte("value1"), time.Millisecond); err != nil {
-					t.Fatalf("Failed to set key1: %v", err)
-				}
+				err = s.Set(t.Context(), "key1", []byte("value1"), time.Millisecond)
+				require.NoError(t, err, "Failed to set key1: %v", err)
 
 				return s
 			},
@@ -370,13 +365,10 @@ func TestInMemoryCacheStorage_GetWithTTL(t *testing.T) {
 				t.Helper()
 
 				s, err := New(10)
-				if err != nil {
-					t.Fatalf("Failed to create InMemoryCacheStorage: %v", err)
-				}
+				require.NoError(t, err, "Failed to create InMemoryCacheStorage: %v", err)
 
-				if err = s.Set(t.Context(), "key2", []byte("value2"), time.Millisecond); err != nil {
-					t.Fatalf("Failed to set key2: %v", err)
-				}
+				err = s.Set(t.Context(), "key2", []byte("value2"), time.Millisecond)
+				require.NoError(t, err, "Failed to set key2: %v", err)
 
 				time.Sleep(2 * time.Millisecond)
 


### PR DESCRIPTION
This pull request refactors the cache handling logic to improve code clarity, maintainability, and test coverage. The main cache request logic is extracted into a new `processRequest` method, and background cache warm-up logic is isolated into a `startWarmUp` method. The test suite is expanded to cover panic recovery, warm-up lock handling, timeout enforcement, and error handling during cache warm-up. Additionally, test code is modernized for better assertion clarity, and a new linter rule is added.

**Cache logic refactoring and improvements:**
- Extracted the core cache request logic from `Cache.Cache` into a new `processRequest` method, improving readability and separation of concerns. The warm-up logic is now handled by a dedicated `startWarmUp` method. (`anycache.go`) [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L134-R134) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R265-R358)
- Added a new panic recovery test, tests for warm-up lock release, timeout handling, and warm-up error handling, ensuring robust behavior and correctness in edge cases. (`anycache_test.go`)

**Testing improvements:**
- Updated in-memory cache storage tests to use `require.NoError` for more concise and expressive error checking, replacing manual error handling. (`storage/inmemory/inmemory_test.go`) [[1]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6R9) [[2]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6L331-R335) [[3]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6L352-R353) [[4]](diffhunk://#diff-e7ba7891eee3db351f79be6a650a95605614348a60a117f3668c530e9dc41ed6L373-R371)

**Linting and code quality:**
- Added a `gocyclo` linter rule with a minimum complexity threshold to `.golangci.yml`, helping to enforce code simplicity and maintainability. (`.golangci.yml`)