### PR TITLE
Fix inmemory storage implementation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,6 @@ ignore:
   - "**/*_mock.go"
   - "*_mock.go"
   - "**/*.pb.go"
+coverage:
+  status:
+    patch: off

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -64,9 +64,9 @@ func (s *Storage) Get(_ context.Context, key string) ([]byte, error) {
 }
 
 // Set stores a value associated with the provided key in the in-memory cache storage.
-func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
-	if s.ctx.Err() != nil {
-		return errors.New("storage is closed")
+func (s *Storage) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	if err := s.checkCtx(ctx); err != nil {
+		return err
 	}
 
 	if ttl < 0 {
@@ -118,9 +118,9 @@ func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Dura
 }
 
 // Del deletes the value associated with the provided key from the in-memory cache storage.
-func (s *Storage) Del(_ context.Context, key string) error {
-	if s.ctx.Err() != nil {
-		return errors.New("storage is closed")
+func (s *Storage) Del(ctx context.Context, key string) error {
+	if err := s.checkCtx(ctx); err != nil {
+		return err
 	}
 
 	s.mu.Lock()
@@ -142,9 +142,9 @@ func (s *Storage) Del(_ context.Context, key string) error {
 }
 
 // GetWithTTL retrieves the value and time-to-live (TTL) associated with the provided key from the in-memory cache storage.
-func (s *Storage) GetWithTTL(_ context.Context, key string) ([]byte, time.Duration, error) {
-	if s.ctx.Err() != nil {
-		return nil, 0, errors.New("storage is closed")
+func (s *Storage) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, error) {
+	if err := s.checkCtx(ctx); err != nil {
+		return nil, 0, err
 	}
 
 	s.mu.Lock()
@@ -218,4 +218,17 @@ func (s *Storage) expiryLoop() {
 			s.mu.Unlock()
 		}
 	}
+}
+
+// checkCtx checks the context of the storage and the provided context for cancellation or closure.
+func (s *Storage) checkCtx(ctx context.Context) error {
+	if s.ctx.Err() != nil {
+		return errors.New("storage is closed")
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return nil
 }

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -226,8 +226,12 @@ func (s *Storage) checkCtx(ctx context.Context) error {
 		return errors.New("storage is closed")
 	}
 
-	if ctx.Err() != nil {
-		return ctx.Err()
+	if ctx == nil {
+		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -111,7 +111,7 @@ func (s *Storage) Set(ctx context.Context, key string, value []byte, ttl time.Du
 	s.index[key] = item
 
 	if item.expiry != nil {
-		s.expiryQ.Push(item)
+		heap.Push(&s.expiryQ, item)
 	}
 
 	return nil

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -82,7 +82,12 @@ func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Dura
 
 	if len(s.index) >= s.limit {
 		leastUsed := s.items.Front()
-		item, _ := leastUsed.Value.(*cacheItem)
+
+		item, ok := leastUsed.Value.(*cacheItem)
+		if !ok {
+			return errors.New("failed to retrieve least recently used item, invalid type assertion")
+		}
+
 		s.delete(item)
 	}
 
@@ -99,14 +104,10 @@ func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Dura
 		expiry: expiry,
 	}
 
-	elem := &list.Element{
-		Value: item,
-	}
+	elem := s.items.PushBack(item)
 
 	item.lruPos = elem
-
 	s.index[key] = item
-	s.items.PushBack(elem)
 	s.expiryQ.Push(item)
 
 	return nil

--- a/storage/inmemory/inmemory.go
+++ b/storage/inmemory/inmemory.go
@@ -91,7 +91,7 @@ func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Dura
 		s.delete(item)
 	}
 
-	var expiry *time.Time
+	var expiry *time.Time = nil
 
 	if ttl > 0 {
 		expTime := time.Now().Add(ttl)
@@ -99,16 +99,20 @@ func (s *Storage) Set(_ context.Context, key string, value []byte, ttl time.Dura
 	}
 
 	item := &cacheItem{
-		key:    key,
-		value:  value,
-		expiry: expiry,
+		key:       key,
+		value:     value,
+		expiry:    expiry,
+		expiryPos: -1,
 	}
 
 	elem := s.items.PushBack(item)
 
 	item.lruPos = elem
 	s.index[key] = item
-	s.expiryQ.Push(item)
+
+	if item.expiry != nil {
+		s.expiryQ.Push(item)
+	}
 
 	return nil
 }

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -497,7 +497,22 @@ func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3 after eviction, but got %d", s.items.Len())
 	assert.Equal(t, 3, len(s.index), "Expected index size to be 3 after eviction, but got %d", len(s.index))
 	assert.Equal(t, 3, len(s.expiryQ), "Expected expiry queue size to be 3 after eviction, but got %d", len(s.expiryQ))
-}
+
+	for i := 1; i <= 3; i++ {
+		_, err := s.Get(t.Context(), fmt.Sprintf("key%d", i))
+		assert.Error(t, err, "Expected key%d to be evicted, but it was still present", i)
+	}
+
+	for i := 1; i <= 3; i++ {
+		_, err := s.Get(t.Context(), fmt.Sprintf("newKey%d", i))
+		assert.Error(t, err, "Expected newKey%d to be evicted, but it was still present", i)
+	}
+
+	for i := 4; i <= 6; i++ {
+		got, err := s.Get(t.Context(), fmt.Sprintf("newKey%d", i))
+		assert.NoError(t, err, "Expected newKey%d to remain in cache, but got error: %v", i, err)
+		assert.Equal(t, fmt.Sprintf("newValue%d", i), string(got), "Expected newKey%d to have correct value", i)
+	}
 
 func TestInMemory_LRUEviction_AccessOrder(t *testing.T) {
 	s, err := New(3)

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -532,5 +532,5 @@ func TestInMemory_LRUEviction_AccessOrder(t *testing.T) {
 
 	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
 	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
-	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 0, but got %d", len(s.expiryQ))
 }

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -481,7 +481,7 @@ func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	for i := 1; i <= 3; i++ {
-		err := s.Set(t.Context(), fmt.Sprintf("key%d", i), []byte(fmt.Sprintf("value%d", i)), time.Second)
+		err := s.Set(t.Context(), fmt.Sprintf("key%d", i), []byte(fmt.Sprintf("value%d", i)), time.Minute)
 		require.NoError(t, err, "Failed to set key%d: %v", i, err)
 	}
 
@@ -490,7 +490,7 @@ func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 	assert.Equal(t, 3, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
 
 	for i := 1; i <= 6; i++ {
-		err := s.Set(t.Context(), fmt.Sprintf("newKey%d", i), []byte(fmt.Sprintf("newValue%d", i)), time.Second)
+		err := s.Set(t.Context(), fmt.Sprintf("newKey%d", i), []byte(fmt.Sprintf("newValue%d", i)), time.Minute)
 		require.NoError(t, err, "Failed to set newKey%d: %v", i, err)
 	}
 

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -462,7 +462,7 @@ func TestInMemory_LRUEviction_NoTTL(t *testing.T) {
 
 	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
 	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
-	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 0, but got %d", len(s.expiryQ))
 
 	for i := 1; i <= 6; i++ {
 		err := s.Set(t.Context(), fmt.Sprintf("newKey%d", i), []byte(fmt.Sprintf("newValue%d", i)), 0)

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -471,8 +471,23 @@ func TestInMemory_LRUEviction_NoTTL(t *testing.T) {
 
 	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3 after eviction, but got %d", s.items.Len())
 	assert.Equal(t, 3, len(s.index), "Expected index size to be 3 after eviction, but got %d", len(s.index))
-	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3 after eviction, but got %d", len(s.expiryQ))
-}
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 0 after eviction, but got %d", len(s.expiryQ))
+
+	for i := 1; i <= 3; i++ {
+		_, err := s.Get(t.Context(), fmt.Sprintf("key%d", i))
+		assert.Error(t, err, "Expected key%d to be evicted, but it was still present", i)
+	}
+
+	for i := 1; i <= 3; i++ {
+		_, err := s.Get(t.Context(), fmt.Sprintf("newKey%d", i))
+		assert.Error(t, err, "Expected newKey%d to be evicted, but it was still present", i)
+	}
+
+	for i := 4; i <= 6; i++ {
+		got, err := s.Get(t.Context(), fmt.Sprintf("newKey%d", i))
+		assert.NoError(t, err, "Expected newKey%d to remain in cache, but got error: %v", i, err)
+		assert.Equal(t, fmt.Sprintf("newValue%d", i), string(got), "Expected newKey%d to have correct value", i)
+	}
 
 func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 	s, err := New(3)

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -498,3 +498,39 @@ func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 	assert.Equal(t, 3, len(s.index), "Expected index size to be 3 after eviction, but got %d", len(s.index))
 	assert.Equal(t, 3, len(s.expiryQ), "Expected expiry queue size to be 3 after eviction, but got %d", len(s.expiryQ))
 }
+
+func TestInMemory_LRUEviction_AccessOrder(t *testing.T) {
+	s, err := New(3)
+	require.NoError(t, err, "Failed to create InMemoryCacheStorage: %v", err)
+
+	t.Cleanup(func() { _ = s.Close() })
+
+	for i := 1; i <= 3; i++ {
+		err := s.Set(t.Context(), fmt.Sprintf("key%d", i), []byte(fmt.Sprintf("value%d", i)), 0)
+		require.NoError(t, err, "Failed to set key%d: %v", i, err)
+	}
+
+	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
+	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+
+	value, err := s.Get(t.Context(), "key1")
+
+	assert.NoError(t, err, "Failed to get key1: %v", err)
+	assert.Equal(t, "value1", string(value), "Expected to get value1, but got '%v'", string(value))
+
+	err = s.Set(t.Context(), "key4", []byte("value4"), 0)
+	require.NoError(t, err, "Failed to set key4: %v", err)
+
+	value, err = s.Get(t.Context(), "key2")
+	assert.Error(t, err, "Expected to get an error for key2, but got nil")
+	assert.Equal(t, "", string(value), "Expected to get an empty value for key2, but got '%v'", string(value))
+
+	value, err = s.Get(t.Context(), "key1")
+	assert.NoError(t, err, "Failed to get key1: %v", err)
+	assert.Equal(t, "value1", string(value), "Expected to get value1, but got '%v'", string(value))
+
+	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
+	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+}

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -2,6 +2,7 @@ package inmemory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -446,4 +447,54 @@ func TestInMemoryCacheStorage_Close(t *testing.T) {
 	if err == nil {
 		t.Fatal("Close() succeeded unexpectedly on already closed storage")
 	}
+}
+
+func TestInMemory_LRUEviction_NoTTL(t *testing.T) {
+	s, err := New(3)
+	require.NoError(t, err, "Failed to create InMemoryCacheStorage: %v", err)
+
+	t.Cleanup(func() { _ = s.Close() })
+
+	for i := 1; i <= 3; i++ {
+		err := s.Set(t.Context(), fmt.Sprintf("key%d", i), []byte(fmt.Sprintf("value%d", i)), 0)
+		require.NoError(t, err, "Failed to set key%d: %v", i, err)
+	}
+
+	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
+	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+
+	for i := 1; i <= 6; i++ {
+		err := s.Set(t.Context(), fmt.Sprintf("newKey%d", i), []byte(fmt.Sprintf("newValue%d", i)), 0)
+		require.NoError(t, err, "Failed to set newKey%d: %v", i, err)
+	}
+
+	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3 after eviction, but got %d", s.items.Len())
+	assert.Equal(t, 3, len(s.index), "Expected index size to be 3 after eviction, but got %d", len(s.index))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3 after eviction, but got %d", len(s.expiryQ))
+}
+
+func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
+	s, err := New(3)
+	require.NoError(t, err, "Failed to create InMemoryCacheStorage: %v", err)
+
+	t.Cleanup(func() { _ = s.Close() })
+
+	for i := 1; i <= 3; i++ {
+		err := s.Set(t.Context(), fmt.Sprintf("key%d", i), []byte(fmt.Sprintf("value%d", i)), time.Second)
+		require.NoError(t, err, "Failed to set key%d: %v", i, err)
+	}
+
+	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
+	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
+	assert.Equal(t, 3, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+
+	for i := 1; i <= 6; i++ {
+		err := s.Set(t.Context(), fmt.Sprintf("newKey%d", i), []byte(fmt.Sprintf("newValue%d", i)), time.Second)
+		require.NoError(t, err, "Failed to set newKey%d: %v", i, err)
+	}
+
+	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3 after eviction, but got %d", s.items.Len())
+	assert.Equal(t, 3, len(s.index), "Expected index size to be 3 after eviction, but got %d", len(s.index))
+	assert.Equal(t, 3, len(s.expiryQ), "Expected expiry queue size to be 3 after eviction, but got %d", len(s.expiryQ))
 }

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -488,6 +488,7 @@ func TestInMemory_LRUEviction_NoTTL(t *testing.T) {
 		assert.NoError(t, err, "Expected newKey%d to remain in cache, but got error: %v", i, err)
 		assert.Equal(t, fmt.Sprintf("newValue%d", i), string(got), "Expected newKey%d to have correct value", i)
 	}
+}
 
 func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 	s, err := New(3)
@@ -528,6 +529,7 @@ func TestInMemory_LRUEviction_WithTTL(t *testing.T) {
 		assert.NoError(t, err, "Expected newKey%d to remain in cache, but got error: %v", i, err)
 		assert.Equal(t, fmt.Sprintf("newValue%d", i), string(got), "Expected newKey%d to have correct value", i)
 	}
+}
 
 func TestInMemory_LRUEviction_AccessOrder(t *testing.T) {
 	s, err := New(3)

--- a/storage/inmemory/inmemory_test.go
+++ b/storage/inmemory/inmemory_test.go
@@ -512,7 +512,7 @@ func TestInMemory_LRUEviction_AccessOrder(t *testing.T) {
 
 	assert.Equal(t, 3, s.items.Len(), "Expected list size to be 3, but got %d", s.items.Len())
 	assert.Equal(t, 3, len(s.index), "Expected index size to be 3, but got %d", len(s.index))
-	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 3, but got %d", len(s.expiryQ))
+	assert.Equal(t, 0, len(s.expiryQ), "Expected expiry queue size to be 0, but got %d", len(s.expiryQ))
 
 	value, err := s.Get(t.Context(), "key1")
 


### PR DESCRIPTION
This pull request improves the reliability and correctness of the in-memory cache storage implementation, with a focus on context handling, LRU (Least Recently Used) eviction logic, and comprehensive testing. The main changes include refactoring context management, fixing potential type assertion issues, and adding new tests to validate LRU eviction behavior.

### Reliability and Context Handling Improvements

* Refactored the `Set`, `Del`, and `GetWithTTL` methods in `inmemory.go` to use a new `checkCtx` helper, which checks both the storage's internal context and the provided context for cancellation or closure. This ensures more robust error handling and proper context propagation. [[1]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L67-R69) [[2]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L140-R147) [[3]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925R222-R234)

### LRU Eviction Logic Fixes

* Updated the LRU eviction logic in the `Set` method to safely handle type assertions and ensure that only valid cache items are evicted. Added explicit error handling for type assertion failures and clarified the initialization of the expiry pointer. [[1]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925L85-R94) [[2]](diffhunk://#diff-bfeba6399e28b862c5be3390d535265f84a50d54896efdb8cc77218adc8fc925R105-R123)

### Testing Enhancements

* Added three new tests in `inmemory_test.go` to thoroughly validate LRU eviction behavior:
  - `TestInMemory_LRUEviction_NoTTL`: Tests eviction when items have no TTL.
  - `TestInMemory_LRUEviction_WithTTL`: Tests eviction when items have a TTL.
  - `TestInMemory_LRUEviction_AccessOrder`: Tests that access order affects which items are evicted.
  These tests ensure the cache behaves correctly under different scenarios.

* Added necessary imports (e.g., `fmt`) to support the new tests.

Overall, these changes make the in-memory cache more robust, reliable, and well-tested.