### PR TITLE
Custom codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ if err := cache.Invalidate(ctx, "user:profile"); err != nil {
 - `WithKeyPrefix(prefix)` — namespace keys.
 - `WithBaseContext(ctx)` — set base context for internal/background work.
 - `WithMetricHook(func(key string, op anycache.State, latency time.Duration))` — default per-request metric hook.
+- `WithCodec(codec)` — override default JSON codec for `CacheStruct`.
 
 ### Request-level options
 

--- a/anycache.go
+++ b/anycache.go
@@ -168,7 +168,7 @@ func (c *Cache) CacheS(ctx context.Context, key string, ttl time.Duration, gener
 	return string(val), nil
 }
 
-// CacheStruct caches a generated value as JSON and unmarshals it into result.
+// CacheStruct caches a generated value as encoded bytes string and decodes it into result.
 //
 // result must be a pointer that can be unmarshaled into.
 // ttl must be greater than zero.

--- a/anycache.go
+++ b/anycache.go
@@ -3,7 +3,6 @@ package anycache
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -45,6 +44,7 @@ type CacheStorage interface {
 // Cache provides cache-aside operations on top of a CacheStorage backend.
 type Cache struct {
 	Storage     CacheStorage
+	codec       Codec
 	ctx         context.Context
 	sf          singleflight.Group
 	cancelCtx   context.CancelFunc
@@ -79,6 +79,7 @@ func New(store CacheStorage, opts ...CacheOptions) *Cache {
 		Storage:   store,
 		ctx:       ctx,
 		cancelCtx: cancelCtx,
+		codec:     JSONCodec{},
 	}
 
 	for _, opt := range opts {
@@ -178,12 +179,12 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, ttl time.Duration, 
 			return nil, err
 		}
 
-		jsonVal, err := json.Marshal(val)
+		data, err := c.codec.Encode(val)
 		if err != nil {
 			return nil, err
 		}
 
-		return jsonVal, nil
+		return data, nil
 	}
 
 	val, err := c.Cache(ctx, key, ttl, generatorWrapper, opts...)
@@ -191,7 +192,7 @@ func (c *Cache) CacheStruct(ctx context.Context, key string, ttl time.Duration, 
 		return err
 	}
 
-	err = json.Unmarshal(val, result)
+	err = c.codec.Decode(val, result)
 
 	return err
 }

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -112,31 +112,115 @@ func TestCacheJSON(t *testing.T) {
 	cache := New(store)
 	store.EXPECT().Get(mock.Anything, "TestCacheJSONKey").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "TestCacheJSONKey", []byte("{\"foo\":\"bar\"}"), mock.Anything).Return(nil)
-	// Define a test key and value
+
 	key := "TestCacheJSONKey"
 	value := map[string]string{
 		"foo": "bar",
 	}
 
-	// Define a generator function that returns the test value
 	generator := func(_ context.Context) (any, error) {
 		return value, nil
 	}
 
-	// Define a result variable to hold the unmarshalled JSON value
 	var result map[string]string
 
-	// Call the CacheJSON function to cache the test value
 	err := cache.CacheStruct(t.Context(), key, time.Second, generator, &result)
-	// Check that the function returned no errors
 	if err != nil {
 		t.Errorf("CacheJSON returned an error: %v", err)
 	}
 
-	// Check that the result variable contains the expected value
 	if result["foo"] != "bar" {
 		t.Errorf("CacheJSON returned an unexpected value: %v", result)
 	}
+}
+
+type testCodec struct {
+	encodeFn func(value any) ([]byte, error)
+	decodeFn func(data []byte, value any) error
+}
+
+func (tc testCodec) Encode(value any) ([]byte, error) {
+	return tc.encodeFn(value)
+}
+
+func (tc testCodec) Decode(data []byte, value any) error {
+	return tc.decodeFn(data, value)
+}
+
+func TestCacheStruct_UsesCustomCodec(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	codec := testCodec{
+		encodeFn: func(value any) ([]byte, error) {
+			assert.Equal(t, map[string]string{"foo": "bar"}, value)
+			return []byte("encoded"), nil
+		},
+		decodeFn: func(data []byte, value any) error {
+			assert.Equal(t, []byte("encoded"), data)
+
+			out, ok := value.(*map[string]string)
+			assert.True(t, ok)
+
+			(*out)["foo"] = "bar"
+
+			return nil
+		},
+	}
+	cache := New(store, WithCodec(codec))
+
+	store.EXPECT().Get(mock.Anything, "custom-codec").Return(nil, ErrKeyNotExists)
+	store.EXPECT().Set(mock.Anything, "custom-codec", []byte("encoded"), mock.Anything).Return(nil)
+
+	var result = map[string]string{}
+
+	err := cache.CacheStruct(t.Context(), "custom-codec", time.Second, func(_ context.Context) (any, error) {
+		return map[string]string{"foo": "bar"}, nil
+	}, &result)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", result["foo"])
+}
+
+func TestCacheStruct_CustomCodecEncodeError(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	codec := testCodec{
+		encodeFn: func(_ any) ([]byte, error) {
+			return nil, assert.AnError
+		},
+		decodeFn: func(_ []byte, _ any) error {
+			return nil
+		},
+	}
+	cache := New(store, WithCodec(codec))
+
+	store.EXPECT().Get(mock.Anything, "custom-codec-encode-error").Return(nil, ErrKeyNotExists)
+
+	err := cache.CacheStruct(t.Context(), "custom-codec-encode-error", time.Second, func(_ context.Context) (any, error) {
+		return map[string]string{"foo": "bar"}, nil
+	}, &map[string]string{})
+
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestCacheStruct_CustomCodecDecodeError(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	codec := testCodec{
+		encodeFn: func(_ any) ([]byte, error) {
+			return []byte("encoded"), nil
+		},
+		decodeFn: func(_ []byte, _ any) error {
+			return assert.AnError
+		},
+	}
+	cache := New(store, WithCodec(codec))
+
+	store.EXPECT().Get(mock.Anything, "custom-codec-decode-error").Return([]byte("encoded"), nil)
+
+	err := cache.CacheStruct(t.Context(), "custom-codec-decode-error", time.Second, func(_ context.Context) (any, error) {
+		t.Fatal("generator should not be called on cache hit")
+		return nil, nil
+	}, &map[string]string{})
+
+	assert.ErrorIs(t, err, assert.AnError)
 }
 
 func TestCancelingRequest(t *testing.T) {

--- a/cache_options.go
+++ b/cache_options.go
@@ -52,3 +52,14 @@ func WithMetricHook(hook func(key string, op State, latency time.Duration)) func
 		c.observer = hook
 	}
 }
+
+// WithCodec sets the codec used for encoding and decoding cache values.
+func WithCodec(codec Codec) func(*Cache) {
+	if codec == nil {
+		panic("codec cannot be nil")
+	}
+
+	return func(c *Cache) {
+		c.codec = codec
+	}
+}

--- a/cache_options_test.go
+++ b/cache_options_test.go
@@ -121,3 +121,18 @@ func TestWithMetricHook_PanicsOnNilHook(t *testing.T) {
 		WithMetricHook(nil)
 	})
 }
+
+func TestWithCodec(t *testing.T) {
+	mockStorage := NewMockCacheStorage(t)
+	codec := JSONCodec{}
+
+	cache := New(mockStorage, WithCodec(codec))
+
+	assert.Equal(t, codec, cache.codec)
+}
+
+func TestWithCodec_PanicsOnNilCodec(t *testing.T) {
+	assert.PanicsWithValue(t, "codec cannot be nil", func() {
+		WithCodec(nil)
+	})
+}

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,22 @@
+package anycache
+
+import "encoding/json"
+
+// Codec defines the interface for encoding and decoding values to and from byte slices.
+type Codec interface {
+	Decode(data []byte, value any) error
+	Encode(value any) ([]byte, error)
+}
+
+// JSONCodec is a codec that uses JSON marshaling and unmarshaling for encoding and decoding values.
+type JSONCodec struct{}
+
+// Encode encodes the given value into a JSON byte slice using JSON marshaling.
+func (c JSONCodec) Encode(value any) ([]byte, error) {
+	return json.Marshal(value)
+}
+
+// Decode decodes the given data into the provided value using JSON unmarshaling.
+func (c JSONCodec) Decode(data []byte, value any) error {
+	return json.Unmarshal(data, value)
+}

--- a/codec.go
+++ b/codec.go
@@ -3,6 +3,8 @@ package anycache
 import "encoding/json"
 
 // Codec defines the interface for encoding and decoding values to and from byte slices.
+// Implementations must be safe for concurrent use by multiple goroutines.
+// Decode expects value to be a pointer to the destination type.
 type Codec interface {
 	Decode(data []byte, value any) error
 	Encode(value any) ([]byte, error)

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,47 @@
+package anycache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONCodec_Encode(t *testing.T) {
+	codec := JSONCodec{}
+	value := map[string]string{"foo": "bar"}
+
+	data, err := codec.Encode(value)
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"foo":"bar"}`, string(data))
+}
+
+func TestJSONCodec_Decode(t *testing.T) {
+	codec := JSONCodec{}
+	data := []byte(`{"foo":"bar"}`)
+
+	var result map[string]string
+
+	err := codec.Decode(data, &result)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", result["foo"])
+}
+
+func TestJSONCodec_EncodeError(t *testing.T) {
+	codec := JSONCodec{}
+
+	_, err := codec.Encode(make(chan int))
+
+	assert.Error(t, err)
+}
+
+func TestJSONCodec_DecodeError(t *testing.T) {
+	codec := JSONCodec{}
+
+	var result map[string]string
+
+	err := codec.Decode([]byte("{invalid json}"), &result)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This pull request introduces a pluggable codec interface to the `anycache` package, allowing users to customize how values are encoded and decoded when using `CacheStruct`. The default remains JSON, but this makes it easy to swap in other serialization formats. The most important changes are:

### Codec abstraction and implementation

* Added a new `Codec` interface in `codec.go` that defines `Encode` and `Decode` methods, along with a default `JSONCodec` implementation using the standard library's JSON marshaling.
* Updated the `Cache` struct to include a `codec` field, which is initialized to `JSONCodec` by default in `New`. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R47) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R82)

### Pluggable codec support

* Added a `WithCodec(codec)` option to allow users to override the default codec when constructing a `Cache` instance. [[1]](diffhunk://#diff-affa275e62df18829f1384a753b19561dfe5882b566ec6fb2b8cb908a4e1eed8R55-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111)
* Refactored `CacheStruct` to use the configured codec for encoding and decoding values, instead of hardcoding JSON serialization.

### Code cleanup

* Removed the direct import of `encoding/json` from `anycache.go`, since encoding responsibilities are now managed by the codec abstraction.