### PR TITLE
Bypass cache based on result

### DIFF
--- a/anycache.go
+++ b/anycache.go
@@ -57,14 +57,16 @@ type Cache struct {
 }
 
 type Request struct {
-	ctx        context.Context
-	MetricHook func(key string, op State, latency time.Duration)
-	TTL        time.Duration
-	WarmUpTTL  time.Duration
-	Timeout    time.Duration
+	ctx         context.Context
+	MetricHook  func(key string, op State, latency time.Duration)
+	TTL         time.Duration
+	WarmUpTTL   time.Duration
+	Timeout     time.Duration
+	isCacheable func([]byte) bool
 }
 
 type (
+	generator       func(ctx context.Context) ([]byte, bool, error)
 	CacheGenerator  func(ctx context.Context) ([]byte, error)
 	CacheGeneratorS func(ctx context.Context) (string, error)
 	CacheOptions    func(*Cache)
@@ -128,8 +130,20 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 
 	// appending common key prefix after  Metrics hook, to simplify key parsing for observability
 	key = c.keyPrefix + key
+	gen := func(ctx context.Context) ([]byte, bool, error) {
+		res, err := generator(ctx)
+		if err != nil {
+			return nil, false, err
+		}
 
-	res := c.processRequest(key, generator, req)
+		if req.isCacheable != nil && !req.isCacheable(res) {
+			return res, false, err
+		}
+
+		return res, true, nil
+	}
+
+	res := c.processRequest(key, gen, req)
 
 	select {
 	case <-ctx.Done():
@@ -213,10 +227,14 @@ func (c *Cache) Invalidate(ctx context.Context, key string) error {
 // generateAndSet generates a value using the provided generator function,
 // sets it in the cache storage with the given key and options,
 // and returns the generated value and any error encountered.
-func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator CacheGenerator) ([]byte, error) {
-	value, err := generator(ctx)
+func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator generator) ([]byte, error) {
+	value, cachable, err := generator(ctx)
 	if err != nil {
 		return value, err
+	}
+
+	if !cachable {
+		return value, nil
 	}
 
 	ttl = randomizeTTL(c.maxShiftTTL, ttl)
@@ -255,7 +273,7 @@ func (c *Cache) Close() error {
 }
 
 // processRequest processes a cache request for the given key using the provided generator function and request options.
-func (c *Cache) processRequest(key string, generator CacheGenerator, req Request) <-chan singleflight.Result {
+func (c *Cache) processRequest(key string, generator generator, req Request) <-chan singleflight.Result {
 	return c.sf.DoChan(key, func() (value any, err error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -328,7 +346,7 @@ func (c *Cache) processRequest(key string, generator CacheGenerator, req Request
 
 // startWarmUp starts a background goroutine to warm up the cache for the given key
 // using the provided generator function and request options.
-func (c *Cache) startWarmUp(key string, generator CacheGenerator, req Request) {
+func (c *Cache) startWarmUp(key string, generator generator, req Request) {
 	c.wg.Go(func() {
 		defer c.warmUpLocks.Delete(key)
 

--- a/anycache.go
+++ b/anycache.go
@@ -271,6 +271,7 @@ func (c *Cache) Close() error {
 	return nil
 }
 
+// processRequestWithDeDuplication processes a cache request for the given key using the provided generator function and request options.
 func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string, generator generator, req Request) (*result, error) {
 	res := c.sf.DoChan(key, func() (value any, err error) {
 		return c.processRequest(key, generator, req)

--- a/anycache.go
+++ b/anycache.go
@@ -226,8 +226,8 @@ func (c *Cache) Invalidate(ctx context.Context, key string) error {
 // generateAndSet generates a value using the provided generator function,
 // sets it in the cache storage with the given key and options,
 // and returns the generated value and any error encountered.
-func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator generator) ([]byte, error) {
-	value, cacheable, err := generator(ctx)
+func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, gen generator) ([]byte, error) {
+	value, cacheable, err := gen(ctx)
 	if err != nil {
 		return value, err
 	}

--- a/anycache.go
+++ b/anycache.go
@@ -62,7 +62,7 @@ type Request struct {
 	TTL         time.Duration
 	WarmUpTTL   time.Duration
 	Timeout     time.Duration
-	isCacheable func([]byte) bool
+	shouldCache func([]byte) bool
 }
 
 type (
@@ -136,7 +136,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 			return nil, false, err
 		}
 
-		if req.isCacheable != nil && !req.isCacheable(res) {
+		if req.shouldCache != nil && !req.shouldCache(res) {
 			return res, false, err
 		}
 
@@ -148,7 +148,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		err error
 	)
 
-	if req.isCacheable != nil {
+	if req.shouldCache != nil {
 		val, err = c.processRequest(key, gen, req)
 	} else {
 		val, err = c.processRequestWithDeDuplication(ctx, key, gen, req)
@@ -227,12 +227,12 @@ func (c *Cache) Invalidate(ctx context.Context, key string) error {
 // sets it in the cache storage with the given key and options,
 // and returns the generated value and any error encountered.
 func (c *Cache) generateAndSet(ctx context.Context, key string, ttl time.Duration, generator generator) ([]byte, error) {
-	value, cachable, err := generator(ctx)
+	value, cacheable, err := generator(ctx)
 	if err != nil {
 		return value, err
 	}
 
-	if !cachable {
+	if !cacheable {
 		return value, nil
 	}
 

--- a/anycache.go
+++ b/anycache.go
@@ -143,25 +143,24 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		return res, true, nil
 	}
 
-	res := c.processRequest(key, gen, req)
+	var (
+		val *result
+		err error
+	)
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-res:
-		if resp.Err != nil {
-			return nil, resp.Err
-		}
-
-		val, ok := resp.Val.(*result)
-		if !ok {
-			return nil, errors.New("unexpected value type returned from cache processing")
-		}
-
-		state = val.state
-
-		return val.data, nil
+	if req.isCacheable != nil {
+		val, err = c.processRequest(key, gen, req)
+	} else {
+		val, err = c.processRequestWithDeDuplication(ctx, key, gen, req)
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	state = val.state
+
+	return val.data, nil
 }
 
 // CacheS is a convenience method that wraps the Cache method to return a string value instead of a byte slice.
@@ -272,76 +271,96 @@ func (c *Cache) Close() error {
 	return nil
 }
 
-// processRequest processes a cache request for the given key using the provided generator function and request options.
-func (c *Cache) processRequest(key string, generator generator, req Request) <-chan singleflight.Result {
-	return c.sf.DoChan(key, func() (value any, err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("cache.Cache panicked: %v", r)
-				value = nil
-			}
-		}()
-
-		if req.Timeout > 0 {
-			var cancel context.CancelFunc
-
-			req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
-			defer cancel()
-		}
-
-		var (
-			sfState            State
-			data               []byte
-			needWarmUp         bool
-			acquiredWarmUpLock bool
-			warmUpStarted      bool
-		)
-
-		defer func() {
-			if acquiredWarmUpLock && !warmUpStarted {
-				c.warmUpLocks.Delete(key)
-			}
-		}()
-
-		if req.WarmUpTTL > 0 {
-			var ttl time.Duration
-
-			_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
-			acquiredWarmUpLock = !warmUpLockBusy
-
-			data, ttl, err = c.Storage.GetWithTTL(req.ctx, key)
-
-			readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
-			if err == nil && readyForWarmUp {
-				needWarmUp = true
-			}
-		} else {
-			data, err = c.Storage.Get(req.ctx, key)
-		}
-
-		switch {
-		case errors.Is(err, ErrKeyNotExists):
-			sfState = CacheMiss
-
-			data, err = c.generateAndSet(req.ctx, key, req.TTL, generator)
-			if err != nil {
-				return nil, err
-			}
-		case err != nil:
-			return nil, err
-		default:
-			sfState = CacheHit
-		}
-
-		if needWarmUp && acquiredWarmUpLock {
-			c.startWarmUp(key, generator, req)
-
-			warmUpStarted = true
-			sfState = CacheWarmUp
-		}
-
-		return &result{data: data, state: sfState}, err
+func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string, generator generator, req Request) (*result, error) {
+	res := c.sf.DoChan(key, func() (value any, err error) {
+		return c.processRequest(key, generator, req)
 	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case resp := <-res:
+		if resp.Err != nil {
+			return nil, resp.Err
+		}
+
+		val, ok := resp.Val.(*result)
+		if !ok {
+			return nil, errors.New("unexpected value type returned from cache processing")
+		}
+
+		return val, nil
+	}
+}
+
+// processRequest processes a cache request for the given key using the provided generator function and request options.
+func (c *Cache) processRequest(key string, generator generator, req Request) (value *result, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cache.Cache panicked: %v", r)
+			value = nil
+		}
+	}()
+
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+
+		req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+		defer cancel()
+	}
+
+	var (
+		sfState            State
+		data               []byte
+		needWarmUp         bool
+		acquiredWarmUpLock bool
+		warmUpStarted      bool
+	)
+
+	defer func() {
+		if acquiredWarmUpLock && !warmUpStarted {
+			c.warmUpLocks.Delete(key)
+		}
+	}()
+
+	if req.WarmUpTTL > 0 {
+		var ttl time.Duration
+
+		_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
+		acquiredWarmUpLock = !warmUpLockBusy
+
+		data, ttl, err = c.Storage.GetWithTTL(req.ctx, key)
+
+		readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
+		if err == nil && readyForWarmUp {
+			needWarmUp = true
+		}
+	} else {
+		data, err = c.Storage.Get(req.ctx, key)
+	}
+
+	switch {
+	case errors.Is(err, ErrKeyNotExists):
+		sfState = CacheMiss
+
+		data, err = c.generateAndSet(req.ctx, key, req.TTL, generator)
+		if err != nil {
+			return nil, err
+		}
+	case err != nil:
+		return nil, err
+	default:
+		sfState = CacheHit
+	}
+
+	if needWarmUp && acquiredWarmUpLock {
+		c.startWarmUp(key, generator, req)
+
+		warmUpStarted = true
+		sfState = CacheWarmUp
+	}
+
+	return &result{data: data, state: sfState}, err
 }
 
 // startWarmUp starts a background goroutine to warm up the cache for the given key

--- a/anycache.go
+++ b/anycache.go
@@ -59,10 +59,10 @@ type Cache struct {
 type Request struct {
 	ctx         context.Context
 	MetricHook  func(key string, op State, latency time.Duration)
+	shouldCache func([]byte) bool
 	TTL         time.Duration
 	WarmUpTTL   time.Duration
 	Timeout     time.Duration
-	shouldCache func([]byte) bool
 }
 
 type (

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -82,6 +82,7 @@ func TestCache_WithShouldCache_SkipsStorageSet(t *testing.T) {
 	store.EXPECT().Get(mock.Anything, "skip-cache").Return(nil, ErrKeyNotExists).Twice()
 
 	var generatorCalls atomic.Int32
+
 	generator := func(_ context.Context) ([]byte, error) {
 		call := generatorCalls.Add(1)
 		return []byte(fmt.Sprintf("generated-%d", call)), nil
@@ -105,12 +106,16 @@ func TestCache_WithShouldCache_DisablesSingleflight(t *testing.T) {
 	store.EXPECT().Get(mock.Anything, "skip-cache-concurrent").Return(nil, ErrKeyNotExists).Twice()
 
 	var generatorCalls atomic.Int32
+
 	started := make(chan struct{}, 2)
 	release := make(chan struct{})
 
+	//nolint:unparam // the parameters are not used in this test
 	generator := func(_ context.Context) ([]byte, error) {
 		call := generatorCalls.Add(1)
+
 		started <- struct{}{}
+
 		<-release
 
 		return []byte(fmt.Sprintf("generated-%d", call)), nil
@@ -123,6 +128,7 @@ func TestCache_WithShouldCache_DisablesSingleflight(t *testing.T) {
 		go func() {
 			val, err := cache.Cache(t.Context(), "skip-cache-concurrent", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
 			results <- val
+
 			errs <- err
 		}()
 	}
@@ -241,7 +247,7 @@ func TestCacheStruct_UsesCustomCodec(t *testing.T) {
 	store.EXPECT().Get(mock.Anything, "custom-codec").Return(nil, ErrKeyNotExists)
 	store.EXPECT().Set(mock.Anything, "custom-codec", []byte("encoded"), mock.Anything).Return(nil)
 
-	var result = map[string]string{}
+	result := map[string]string{}
 
 	err := cache.CacheStruct(t.Context(), "custom-codec", time.Second, func(_ context.Context) (any, error) {
 		return map[string]string{"foo": "bar"}, nil
@@ -603,7 +609,8 @@ func TestCacheMetricHook_KeyNotUsesPrefixedStorageKey(t *testing.T) {
 
 	var observedKey string
 
-	cache := New(store,
+	cache := New(
+		store,
 		WithKeyPrefix("p::"),
 		WithMetricHook(func(key string, _ State, _ time.Duration) {
 			observedKey = key

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -3,6 +3,7 @@ package anycache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,6 +73,76 @@ func TestCacheConcurrency(t *testing.T) {
 	assert.Contains(t, [][]byte{[]byte("testValue"), []byte("testValue1")}, val1, "Expected to get testValue or testValue1 as a result, but got '%v'", val1)
 	assert.Contains(t, [][]byte{[]byte("testValue"), []byte("testValue1")}, val2, "Expected to get testValue or testValue1 as a result, but got '%v'", val2)
 	assert.Equal(t, val1, val2, "Expected to get the same value for both calls, but got '%v' and '%v'", val1, val2)
+}
+
+func TestCache_WithShouldCache_SkipsStorageSet(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().Get(mock.Anything, "skip-cache").Return(nil, ErrKeyNotExists).Twice()
+
+	var generatorCalls atomic.Int32
+	generator := func(_ context.Context) ([]byte, error) {
+		call := generatorCalls.Add(1)
+		return []byte(fmt.Sprintf("generated-%d", call)), nil
+	}
+
+	first, err := cache.Cache(t.Context(), "skip-cache", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("generated-1"), first)
+
+	second, err := cache.Cache(t.Context(), "skip-cache", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("generated-2"), second)
+
+	assert.Equal(t, int32(2), generatorCalls.Load(), "expected generator to run for each request when cache is bypassed")
+}
+
+func TestCache_WithShouldCache_DisablesSingleflight(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().Get(mock.Anything, "skip-cache-concurrent").Return(nil, ErrKeyNotExists).Twice()
+
+	var generatorCalls atomic.Int32
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+
+	generator := func(_ context.Context) ([]byte, error) {
+		call := generatorCalls.Add(1)
+		started <- struct{}{}
+		<-release
+
+		return []byte(fmt.Sprintf("generated-%d", call)), nil
+	}
+
+	results := make(chan []byte, 2)
+	errs := make(chan error, 2)
+
+	for range 2 {
+		go func() {
+			val, err := cache.Cache(t.Context(), "skip-cache-concurrent", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
+			results <- val
+			errs <- err
+		}()
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("expected both generators to start")
+		}
+	}
+
+	close(release)
+
+	assert.NoError(t, <-errs)
+	assert.NoError(t, <-errs)
+
+	actual := []string{string(<-results), string(<-results)}
+	assert.ElementsMatch(t, []string{"generated-1", "generated-2"}, actual)
+	assert.Equal(t, int32(2), generatorCalls.Load(), "expected generator to run twice without singleflight de-duplication")
 }
 
 func TestCacheMetricHook_WarmUp(t *testing.T) {

--- a/request_options.go
+++ b/request_options.go
@@ -30,11 +30,11 @@ func WithTimeout(timeout time.Duration) CacheItemOptions {
 	}
 }
 
-// WithCacheBypass sets a custom function to determine whether the generated value should be cached or not.
+// WithShouldCache sets a predicate that decides whether the generated value should be cached.
 // The function takes the generated value as input and
-// returns a boolean indicating whether to cache it (true) or bypass caching (false).
-func WithCacheBypass(checker func([]byte) bool) CacheItemOptions {
+// returns true to cache it or false to skip caching.
+func WithShouldCache(shouldCache func([]byte) bool) CacheItemOptions {
 	return func(req *Request) {
-		req.isCacheable = checker
+		req.shouldCache = shouldCache
 	}
 }

--- a/request_options.go
+++ b/request_options.go
@@ -29,3 +29,12 @@ func WithTimeout(timeout time.Duration) CacheItemOptions {
 		req.Timeout = timeout
 	}
 }
+
+// WithCacheBypass sets a custom function to determine whether the generated value should be cached or not.
+// The function takes the generated value as input and
+// returns a boolean indicating whether to cache it (true) or bypass caching (false).
+func WithCacheBypass(checker func([]byte) bool) CacheItemOptions {
+	return func(req *Request) {
+		req.isCacheable = checker
+	}
+}

--- a/request_options.go
+++ b/request_options.go
@@ -34,6 +34,10 @@ func WithTimeout(timeout time.Duration) CacheItemOptions {
 // The function takes the generated value as input and
 // returns true to cache it or false to skip caching.
 func WithShouldCache(shouldCache func([]byte) bool) CacheItemOptions {
+	if shouldCache == nil {
+		panic("shouldCache function cannot be nil")
+	}
+
 	return func(req *Request) {
 		req.shouldCache = shouldCache
 	}

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -97,7 +97,7 @@ func TestWithShouldCache_SetsPredicate(t *testing.T) {
 	assert.False(t, req.shouldCache(nil))
 }
 
-func TestWithShouldCache_NotAllowsNilPredicate(t *testing.T) {
+func TestWithShouldCache_DoesNotAllowNilPredicate(t *testing.T) {
 	req := &Request{shouldCache: func([]byte) bool { return true }}
 
 	assert.PanicsWithValue(t, "shouldCache function cannot be nil", func() {

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -83,3 +83,24 @@ func TestWithTimeout_ZeroDuration(t *testing.T) {
 
 	assert.Zero(t, req.Timeout)
 }
+
+func TestWithShouldCache_SetsPredicate(t *testing.T) {
+	req := &Request{}
+	predicate := func(value []byte) bool {
+		return len(value) > 0
+	}
+
+	WithShouldCache(predicate)(req)
+
+	assert.NotNil(t, req.shouldCache)
+	assert.True(t, req.shouldCache([]byte("value")))
+	assert.False(t, req.shouldCache(nil))
+}
+
+func TestWithShouldCache_NotAllowsNilPredicate(t *testing.T) {
+	req := &Request{shouldCache: func([]byte) bool { return true }}
+
+	assert.PanicsWithValue(t, "shouldCache function cannot be nil", func() {
+		WithShouldCache(nil)(req)
+	})
+}


### PR DESCRIPTION
This pull request introduces a new `shouldCache` predicate to the cache system, allowing callers to control whether generated values should be cached or not. When `shouldCache` is set, the cache will skip storing the value and bypass singleflight de-duplication for that request. The PR also includes thorough tests for these new behaviors and updates the relevant cache internals to support this feature.

### Feature: Conditional Caching

* Added a `shouldCache` function field to the `Request` struct, which allows callers to specify a predicate to determine if a generated value should be cached.
* Implemented the `WithShouldCache` option for setting the `shouldCache` predicate, including a panic if `nil` is passed.

### Internal Logic Updates

* Updated cache request handling: if `shouldCache` is set, the cache skips singleflight de-duplication and does not store values when the predicate returns false. Otherwise, the existing de-duplication and storage logic is used. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R133-L151) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R274-R298)
* Refactored internal generator and request processing functions to support the new predicate and its effects on caching and de-duplication. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L216-R238) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L326-R369)

### Testing

* Added tests to verify that when `shouldCache` returns false, generated values are not stored and singleflight de-duplication is bypassed, resulting in multiple generator executions.
* Added unit tests for the `WithShouldCache` option, including correct predicate assignment and panic on `nil`.