### PR TITLE
Timeout context interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ Metric states: `hit`, `miss`, `warm_up`, `error`.
 - **Singleflight dedupe scope:** concurrent requests for the same key are deduplicated within a single `anycache.Cache` instance.
 - **Warm-up behavior (`WithWarmUpTTL`):** when a key exists and its remaining TTL is `> 0` and `<= warmUpTTL`, anycache returns the current cached value immediately and schedules a background refresh.
 - **Warm-up lock semantics:** only one warm-up refresh per key is started at a time; concurrent requests do not start duplicate warm-up goroutines.
-- **Timeout and base context (`WithTimeout` + `WithBaseContext`):** internal storage and generator work runs on the cache base context (default or `WithBaseContext`). With `WithTimeout`, a timeout is applied to that base context for internal work.
-- **Caller cancellation expectations:** because internal work uses the cache base context, caller context values/cancellation are not directly propagated into internal storage/generator execution.
+- **Context model for deduplicated requests:** singleflight-backed requests run storage/generator work on the cache base context (default or `WithBaseContext`) so one caller cancellation does not abort shared work for the same key.
+- **Timeout behavior (`WithTimeout` + caller deadlines):** `WithTimeout` sets an explicit timeout for internal work. If no explicit timeout is set and the caller context has a deadline, that deadline is mirrored as an internal timeout for the shared work.
+- **Caller cancellation expectations:** caller cancellation still stops waiting for that caller, but internal shared work continues on the cache base context.
 - **Lifecycle (`Close`):** call `Close()` during shutdown to cancel background work and wait for in-flight warm-up goroutines to finish.
 
 ## When to use anycache

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Metric states: `hit`, `miss`, `warm_up`, `error`.
 - **Warm-up behavior (`WithWarmUpTTL`):** when a key exists and its remaining TTL is `> 0` and `<= warmUpTTL`, anycache returns the current cached value immediately and schedules a background refresh.
 - **Warm-up lock semantics:** only one warm-up refresh per key is started at a time; concurrent requests do not start duplicate warm-up goroutines.
 - **Context model for deduplicated requests:** singleflight-backed requests run storage/generator work on the cache base context (default or `WithBaseContext`) so one caller cancellation does not abort shared work for the same key.
-- **Timeout behavior (`WithTimeout` + caller deadlines):** `WithTimeout` sets an explicit timeout for internal work. If no explicit timeout is set and the caller context has a deadline, that deadline is mirrored as an internal timeout for the shared work.
+- **Timeout behavior (`WithTimeout` + caller deadlines):** `WithTimeout` sets an explicit timeout for internal work. If no explicit timeout is set and the initiating caller context has a deadline, that deadline is mirrored as an internal timeout for the shared work.
 - **Caller cancellation expectations:** caller cancellation still stops waiting for that caller, but internal shared work continues on the cache base context.
 - **Lifecycle (`Close`):** call `Close()` during shutdown to cancel background work and wait for in-flight warm-up goroutines to finish.
 

--- a/anycache.go
+++ b/anycache.go
@@ -270,15 +270,25 @@ func (c *Cache) Close() error {
 
 // processRequestWithDeDuplication processes a cache request for the given key using the provided generator function and request options.
 func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string, generator generator, req Request) (*result, error) {
-	if deadline, ok := ctx.Deadline(); ok && req.Timeout <= 0 {
-		req.Timeout = time.Until(deadline)
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	// Note we should run single flight always as decoupled context
 	// that single request cancelation didn't affect other requests for the same key.
 	// So we should use c.ctx instead of ctx here.
 	res := c.sf.DoChan(key, func() (value any, err error) {
-		return c.processRequest(c.ctx, key, generator, req)
+		reqLocal := req
+		if reqLocal.Timeout <= 0 {
+			if deadline, ok := ctx.Deadline(); ok {
+				reqLocal.Timeout = time.Until(deadline)
+				if reqLocal.Timeout <= 0 {
+					return nil, context.DeadlineExceeded
+				}
+			}
+		}
+
+		return c.processRequest(c.ctx, key, generator, reqLocal)
 	})
 
 	select {

--- a/anycache.go
+++ b/anycache.go
@@ -274,9 +274,9 @@ func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string,
 		return nil, err
 	}
 
-	// Note we should run single flight always as decoupled context
-	// that single request cancelation didn't affect other requests for the same key.
-	// So we should use c.ctx instead of ctx here.
+	// Note: singleflight work should always run with a decoupled context
+	// so that one caller cancellation doesn't affect other requests for the same key.
+	// Use c.ctx (the cache base context) instead of the caller ctx here.
 	res := c.sf.DoChan(key, func() (value any, err error) {
 		reqLocal := req
 		if reqLocal.Timeout <= 0 {

--- a/anycache.go
+++ b/anycache.go
@@ -57,7 +57,6 @@ type Cache struct {
 }
 
 type Request struct {
-	ctx         context.Context
 	MetricHook  func(key string, op State, latency time.Duration)
 	shouldCache func([]byte) bool
 	TTL         time.Duration
@@ -111,8 +110,6 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 		opt(&req)
 	}
 
-	req.ctx = ctx
-
 	state := CacheError
 	start := time.Now()
 
@@ -149,7 +146,7 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 	)
 
 	if req.shouldCache != nil {
-		val, err = c.processRequest(key, gen, req)
+		val, err = c.processRequest(ctx, key, gen, req)
 	} else {
 		val, err = c.processRequestWithDeDuplication(ctx, key, gen, req)
 	}
@@ -273,8 +270,15 @@ func (c *Cache) Close() error {
 
 // processRequestWithDeDuplication processes a cache request for the given key using the provided generator function and request options.
 func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string, generator generator, req Request) (*result, error) {
+	if deadline, ok := ctx.Deadline(); ok && req.Timeout <= 0 {
+		req.Timeout = time.Until(deadline)
+	}
+
+	// Note we should run single flight always as decoupled context
+	// that single request cancelation didn't affect other requests for the same key.
+	// So we should use c.ctx instead of ctx here.
 	res := c.sf.DoChan(key, func() (value any, err error) {
-		return c.processRequest(key, generator, req)
+		return c.processRequest(c.ctx, key, generator, req)
 	})
 
 	select {
@@ -295,7 +299,7 @@ func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string,
 }
 
 // processRequest processes a cache request for the given key using the provided generator function and request options.
-func (c *Cache) processRequest(key string, generator generator, req Request) (value *result, err error) {
+func (c *Cache) processRequest(ctx context.Context, key string, generator generator, req Request) (value *result, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("cache.Cache panicked: %v", r)
@@ -306,7 +310,7 @@ func (c *Cache) processRequest(key string, generator generator, req Request) (va
 	if req.Timeout > 0 {
 		var cancel context.CancelFunc
 
-		req.ctx, cancel = context.WithTimeout(c.ctx, req.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
 		defer cancel()
 	}
 
@@ -330,21 +334,21 @@ func (c *Cache) processRequest(key string, generator generator, req Request) (va
 		_, warmUpLockBusy := c.warmUpLocks.LoadOrStore(key, struct{}{})
 		acquiredWarmUpLock = !warmUpLockBusy
 
-		data, ttl, err = c.Storage.GetWithTTL(req.ctx, key)
+		data, ttl, err = c.Storage.GetWithTTL(ctx, key)
 
 		readyForWarmUp := ttl > 0 && ttl <= req.WarmUpTTL
 		if err == nil && readyForWarmUp {
 			needWarmUp = true
 		}
 	} else {
-		data, err = c.Storage.Get(req.ctx, key)
+		data, err = c.Storage.Get(ctx, key)
 	}
 
 	switch {
 	case errors.Is(err, ErrKeyNotExists):
 		sfState = CacheMiss
 
-		data, err = c.generateAndSet(req.ctx, key, req.TTL, generator)
+		data, err = c.generateAndSet(ctx, key, req.TTL, generator)
 		if err != nil {
 			return nil, err
 		}

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -332,7 +332,7 @@ func TestCancelingRequest(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // watch to finish set on mock
 }
 
-func TestCache_DefaultContextForwarding_NoWithTimeout(t *testing.T) {
+func TestCache_DefaultContextDecouplesValues_NoWithTimeout(t *testing.T) {
 	type ctxKey string
 
 	const key ctxKey = "request-id"
@@ -343,16 +343,16 @@ func TestCache_DefaultContextForwarding_NoWithTimeout(t *testing.T) {
 	ctx := context.WithValue(context.Background(), key, "req-123")
 
 	store.EXPECT().Get(mock.Anything, "ctx-forwarding").RunAndReturn(func(gotCtx context.Context, _ string) ([]byte, error) {
-		assert.Equal(t, "req-123", gotCtx.Value(key))
+		assert.Nil(t, gotCtx.Value(key))
 		return nil, ErrKeyNotExists
 	})
 	store.EXPECT().Set(mock.Anything, "ctx-forwarding", []byte("generated"), mock.Anything).RunAndReturn(func(gotCtx context.Context, _ string, _ []byte, _ time.Duration) error {
-		assert.Equal(t, "req-123", gotCtx.Value(key))
+		assert.Nil(t, gotCtx.Value(key))
 		return nil
 	})
 
 	result, err := cache.Cache(ctx, "ctx-forwarding", time.Second, func(gotCtx context.Context) ([]byte, error) {
-		assert.Equal(t, "req-123", gotCtx.Value(key))
+		assert.Nil(t, gotCtx.Value(key))
 		return []byte("generated"), nil
 	})
 
@@ -367,13 +367,19 @@ func TestCache_DefaultContextCancellationPropagation_NoWithTimeout(t *testing.T)
 
 		store.EXPECT().Get(mock.Anything, "ctx-deadline").Return(nil, ErrKeyNotExists)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		type ctxKey string
+		const key ctxKey = "request-id"
+
+		ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), key, "req-123"), 100*time.Millisecond)
 		defer cancel()
 
 		generatorStarted := make(chan struct{})
 
 		result, err := cache.Cache(ctx, "ctx-deadline", time.Second, func(genCtx context.Context) ([]byte, error) {
 			close(generatorStarted)
+			assert.Nil(t, genCtx.Value(key), "expected deduplicated work context to be decoupled from caller values")
+			_, hasDeadline := genCtx.Deadline()
+			assert.True(t, hasDeadline, "expected caller deadline to be mirrored as internal timeout")
 			<-genCtx.Done()
 
 			return nil, genCtx.Err()

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -402,6 +402,22 @@ func TestCache_DefaultContextCancellationPropagation_NoWithTimeout(t *testing.T)
 	})
 }
 
+func TestCache_AlreadyCanceledContextReturnsWithoutStartingWork(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := cache.Cache(ctx, "already-canceled", time.Second, func(_ context.Context) ([]byte, error) {
+		t.Fatal("generator should not start for already canceled context")
+		return nil, nil
+	})
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestCache_WithTimeout_DecouplesWorkFromCallerContext(t *testing.T) {
 	type ctxKey string
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -368,6 +368,7 @@ func TestCache_DefaultContextCancellationPropagation_NoWithTimeout(t *testing.T)
 		store.EXPECT().Get(mock.Anything, "ctx-deadline").Return(nil, ErrKeyNotExists)
 
 		type ctxKey string
+
 		const key ctxKey = "request-id"
 
 		ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), key, "req-123"), 100*time.Millisecond)

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -2,7 +2,6 @@ package anycache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -304,32 +303,20 @@ func TestCancelingRequest(t *testing.T) {
 	store := NewMockCacheStorage(t)
 	cache := New(store)
 	store.EXPECT().Get(mock.Anything, "TestCancelingRequestKey").Return(nil, ErrKeyNotExists)
-	store.EXPECT().Set(mock.Anything, "TestCancelingRequestKey", []byte("testValue"), mock.Anything).Return(nil)
-	// Define a generator function that returns the test value
+
 	generator := func(ctx context.Context) ([]byte, error) {
 		<-ctx.Done()
-		return []byte("testValue"), nil
+		return nil, ctx.Err()
 	}
 
-	// Call the CacheJSON function to cache the test value
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
 
 	result, err := cache.Cache(ctx, "TestCancelingRequestKey", 2*time.Second, generator)
-	// Check that the function returned no errors
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("Cache returned unexpected error: %v", err)
-	}
-
-	// Check that the result variable contains the expected value
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Nil(t, result, "Expected to get nil result, but got '%v'", result)
 
-	cancel()
-
-	if err := cache.Close(); err != nil {
-		t.Errorf("Close returned an error: %v", err)
-	}
-
-	time.Sleep(time.Millisecond * 10) // watch to finish set on mock
+	assert.NoError(t, cache.Close())
 }
 
 func TestCache_DefaultContextDecouplesValues_NoWithTimeout(t *testing.T) {

--- a/request_options.go
+++ b/request_options.go
@@ -21,9 +21,9 @@ func WithMetric(hook func(key string, op State, latency time.Duration)) CacheIte
 	}
 }
 
-// WithTimeout sets a timeout for the internal cache work (storage + generation).
-// When set, the internal work runs on the cache base context (see WithBaseContext),
-// so caller cancellation and context values are not propagated to storage/generator.
+// WithTimeout sets an explicit timeout for internal cache work (storage + generation).
+// Internal shared work uses the cache base context (see WithBaseContext);
+// caller cancellation/context values are decoupled from storage/generator execution.
 func WithTimeout(timeout time.Duration) CacheItemOptions {
 	return func(req *Request) {
 		req.Timeout = timeout


### PR DESCRIPTION
This pull request refines the context propagation and timeout behavior for deduplicated cache requests in the `anycache` library. The main focus is to ensure that internal cache work (storage and generator execution) is decoupled from caller context values and cancellation, while still honoring caller-imposed deadlines as internal timeouts if no explicit timeout is set. Documentation and tests are updated to clarify and verify these semantics.

**Context propagation and timeout handling:**
- Internal cache work for deduplicated requests now always runs on the cache's base context, ensuring that a single caller's cancellation or context values do not affect shared work for the same key. However, if the caller context has a deadline and no explicit timeout is set, that deadline is mirrored as an internal timeout for the shared work. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561R273-R281) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L309-R313)
- The `Request` struct no longer stores the caller context, and context is now passed explicitly through internal methods for clarity and correctness. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L60) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L114-L115) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L152-R149) [[4]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L298-R302) [[5]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L333-R351)

**Documentation updates:**
- The `README.md` is updated to clarify the context model for deduplicated requests, the behavior of timeouts, and what happens when a caller cancels a request.
- The `WithTimeout` documentation is improved to clearly state that internal cache work is decoupled from caller context and values.

**Testing improvements:**
- Tests are updated to assert that internal cache work does not inherit caller context values, and that deadlines are mirrored as expected. Test names are adjusted for clarity. [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL335-R335) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL346-R355) [[3]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL370-R382)