### PR TITLE
Enhance cache predicate support and update tests/documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ if err := cache.Invalidate(ctx, "user:profile"); err != nil {
 - `WithWarmUpTTL(d)` — if remaining TTL is below `d`, serve current value and refresh in background.
 - `WithMetric(hook)` — override metric hook for one call.
 - `WithTimeout(d)` — timeout for internal storage + generation work.
+- `WithShouldCache(func(any) bool)` — decide per result whether to persist generated data.
 
 Metric states: `hit`, `miss`, `warm_up`, `error`.
 
@@ -125,6 +126,7 @@ Metric states: `hit`, `miss`, `warm_up`, `error`.
 - **Warm-up lock semantics:** only one warm-up refresh per key is started at a time; concurrent requests do not start duplicate warm-up goroutines.
 - **Context model for deduplicated requests:** singleflight-backed requests run storage/generator work on the cache base context (default or `WithBaseContext`) so one caller cancellation does not abort shared work for the same key.
 - **Timeout behavior (`WithTimeout` + caller deadlines):** `WithTimeout` sets an explicit timeout for internal work. If no explicit timeout is set and the initiating caller context has a deadline, that deadline is mirrored as an internal timeout for the shared work.
+- **Conditional caching (`WithShouldCache`):** the predicate receives the original generator value type used by the API call (`[]byte` for `Cache`, `string` for `CacheS`, and the original struct/object for `CacheStruct`). Return `false` to skip storing while still returning generated data.
 - **Caller cancellation expectations:** caller cancellation still stops waiting for that caller, but internal shared work continues on the cache base context.
 - **Lifecycle (`Close`):** call `Close()` during shutdown to cancel background work and wait for in-flight warm-up goroutines to finish.
 

--- a/anycache.go
+++ b/anycache.go
@@ -58,7 +58,7 @@ type Cache struct {
 
 type Request struct {
 	MetricHook  func(key string, op State, latency time.Duration)
-	shouldCache func([]byte) bool
+	shouldCache func(any) bool
 	TTL         time.Duration
 	WarmUpTTL   time.Duration
 	Timeout     time.Duration
@@ -97,17 +97,34 @@ func New(store CacheStorage, opts ...CacheOptions) *Cache {
 // opts can customize request behavior (for example warm-up, timeout,
 // or per-request metrics).
 func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, generator CacheGenerator, opts ...CacheItemOptions) ([]byte, error) {
-	if ttl <= 0 {
-		return nil, errors.New("ttl must be greater than zero")
-	}
-
-	req := Request{
+	req := &Request{
 		TTL:        ttl,
 		MetricHook: c.observer,
 	}
 
 	for _, opt := range opts {
-		opt(&req)
+		opt(req)
+	}
+
+	gen := func(ctx context.Context) ([]byte, bool, error) {
+		res, err := generator(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if req.shouldCache != nil && !req.shouldCache(res) {
+			return res, false, err
+		}
+
+		return res, true, nil
+	}
+
+	return c.cache(ctx, key, gen, req)
+}
+
+func (c *Cache) cache(ctx context.Context, key string, gen generator, req *Request) ([]byte, error) {
+	if req.TTL <= 0 {
+		return nil, errors.New("ttl must be greater than zero")
 	}
 
 	state := CacheError
@@ -127,18 +144,6 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 
 	// appending common key prefix after  Metrics hook, to simplify key parsing for observability
 	key = c.keyPrefix + key
-	gen := func(ctx context.Context) ([]byte, bool, error) {
-		res, err := generator(ctx)
-		if err != nil {
-			return nil, false, err
-		}
-
-		if req.shouldCache != nil && !req.shouldCache(res) {
-			return res, false, err
-		}
-
-		return res, true, nil
-	}
 
 	var (
 		val *result
@@ -162,16 +167,29 @@ func (c *Cache) Cache(ctx context.Context, key string, ttl time.Duration, genera
 
 // CacheS is a convenience method that wraps the Cache method to return a string value instead of a byte slice.
 func (c *Cache) CacheS(ctx context.Context, key string, ttl time.Duration, generator CacheGeneratorS, opts ...CacheItemOptions) (string, error) {
-	generatorWrapper := func(ctx context.Context) ([]byte, error) {
-		result, err := generator(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		return []byte(result), nil
+	req := &Request{
+		TTL:        ttl,
+		MetricHook: c.observer,
 	}
 
-	val, err := c.Cache(ctx, key, ttl, generatorWrapper, opts...)
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	generatorWrapper := func(ctx context.Context) ([]byte, bool, error) {
+		res, err := generator(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if req.shouldCache != nil && !req.shouldCache(res) {
+			return []byte(res), false, err
+		}
+
+		return []byte(res), true, nil
+	}
+
+	val, err := c.cache(ctx, key, generatorWrapper, req)
 	if err != nil {
 		return "", err
 	}
@@ -184,21 +202,34 @@ func (c *Cache) CacheS(ctx context.Context, key string, ttl time.Duration, gener
 // result must be a pointer that can be unmarshaled into.
 // ttl must be greater than zero.
 func (c *Cache) CacheStruct(ctx context.Context, key string, ttl time.Duration, generator func(context.Context) (any, error), result any, opts ...CacheItemOptions) error {
-	generatorWrapper := func(ctx context.Context) ([]byte, error) {
+	req := &Request{
+		TTL:        ttl,
+		MetricHook: c.observer,
+	}
+
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	generatorWrapper := func(ctx context.Context) ([]byte, bool, error) {
 		val, err := generator(ctx)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		data, err := c.codec.Encode(val)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
-		return data, nil
+		if req.shouldCache != nil && !req.shouldCache(val) {
+			return data, false, err
+		}
+
+		return data, true, nil
 	}
 
-	val, err := c.Cache(ctx, key, ttl, generatorWrapper, opts...)
+	val, err := c.cache(ctx, key, generatorWrapper, req)
 	if err != nil {
 		return err
 	}
@@ -269,7 +300,7 @@ func (c *Cache) Close() error {
 }
 
 // processRequestWithDeDuplication processes a cache request for the given key using the provided generator function and request options.
-func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string, generator generator, req Request) (*result, error) {
+func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string, generator generator, req *Request) (*result, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -309,7 +340,7 @@ func (c *Cache) processRequestWithDeDuplication(ctx context.Context, key string,
 }
 
 // processRequest processes a cache request for the given key using the provided generator function and request options.
-func (c *Cache) processRequest(ctx context.Context, key string, generator generator, req Request) (value *result, err error) {
+func (c *Cache) processRequest(ctx context.Context, key string, generator generator, req *Request) (value *result, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("cache.Cache panicked: %v", r)
@@ -380,7 +411,7 @@ func (c *Cache) processRequest(ctx context.Context, key string, generator genera
 
 // startWarmUp starts a background goroutine to warm up the cache for the given key
 // using the provided generator function and request options.
-func (c *Cache) startWarmUp(key string, generator generator, req Request) {
+func (c *Cache) startWarmUp(key string, generator generator, req *Request) {
 	c.wg.Go(func() {
 		defer c.warmUpLocks.Delete(key)
 

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -162,6 +162,7 @@ func TestCacheS_WithShouldCache_ReceivesStringValue(t *testing.T) {
 		str, ok := v.(string)
 		assert.True(t, ok)
 		assert.Equal(t, "generated", str)
+
 		return false
 	}
 
@@ -195,10 +196,12 @@ func TestCacheStruct_WithShouldCache_ReceivesStructValue(t *testing.T) {
 		p, ok := v.(payload)
 		assert.True(t, ok)
 		assert.Equal(t, 204, p.Status)
+
 		return false
 	}
 
 	var out1 payload
+
 	err := cache.CacheStruct(t.Context(), "skip-cache-struct", time.Second, func(_ context.Context) (any, error) {
 		return payload{Status: 204}, nil
 	}, &out1, WithShouldCache(predicate))
@@ -206,6 +209,7 @@ func TestCacheStruct_WithShouldCache_ReceivesStructValue(t *testing.T) {
 	assert.Equal(t, payload{Status: 204}, out1)
 
 	var out2 payload
+
 	err = cache.CacheStruct(t.Context(), "skip-cache-struct", time.Second, func(_ context.Context) (any, error) {
 		return payload{Status: 204}, nil
 	}, &out2, WithShouldCache(predicate))

--- a/anycache_test.go
+++ b/anycache_test.go
@@ -87,11 +87,11 @@ func TestCache_WithShouldCache_SkipsStorageSet(t *testing.T) {
 		return []byte(fmt.Sprintf("generated-%d", call)), nil
 	}
 
-	first, err := cache.Cache(t.Context(), "skip-cache", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
+	first, err := cache.Cache(t.Context(), "skip-cache", time.Second, generator, WithShouldCache(func(any) bool { return false }))
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("generated-1"), first)
 
-	second, err := cache.Cache(t.Context(), "skip-cache", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
+	second, err := cache.Cache(t.Context(), "skip-cache", time.Second, generator, WithShouldCache(func(any) bool { return false }))
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("generated-2"), second)
 
@@ -125,7 +125,7 @@ func TestCache_WithShouldCache_DisablesSingleflight(t *testing.T) {
 
 	for range 2 {
 		go func() {
-			val, err := cache.Cache(t.Context(), "skip-cache-concurrent", time.Second, generator, WithShouldCache(func([]byte) bool { return false }))
+			val, err := cache.Cache(t.Context(), "skip-cache-concurrent", time.Second, generator, WithShouldCache(func(any) bool { return false }))
 			results <- val
 
 			errs <- err
@@ -148,6 +148,70 @@ func TestCache_WithShouldCache_DisablesSingleflight(t *testing.T) {
 	actual := []string{string(<-results), string(<-results)}
 	assert.ElementsMatch(t, []string{"generated-1", "generated-2"}, actual)
 	assert.Equal(t, int32(2), generatorCalls.Load(), "expected generator to run twice without singleflight de-duplication")
+}
+
+func TestCacheS_WithShouldCache_ReceivesStringValue(t *testing.T) {
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().Get(mock.Anything, "skip-cache-string").Return(nil, ErrKeyNotExists).Twice()
+
+	predicateCalls := 0
+	predicate := func(v any) bool {
+		predicateCalls++
+		str, ok := v.(string)
+		assert.True(t, ok)
+		assert.Equal(t, "generated", str)
+		return false
+	}
+
+	v1, err := cache.CacheS(t.Context(), "skip-cache-string", time.Second, func(_ context.Context) (string, error) {
+		return "generated", nil
+	}, WithShouldCache(predicate))
+	assert.NoError(t, err)
+	assert.Equal(t, "generated", v1)
+
+	v2, err := cache.CacheS(t.Context(), "skip-cache-string", time.Second, func(_ context.Context) (string, error) {
+		return "generated", nil
+	}, WithShouldCache(predicate))
+	assert.NoError(t, err)
+	assert.Equal(t, "generated", v2)
+	assert.Equal(t, 2, predicateCalls)
+}
+
+func TestCacheStruct_WithShouldCache_ReceivesStructValue(t *testing.T) {
+	type payload struct {
+		Status int
+	}
+
+	store := NewMockCacheStorage(t)
+	cache := New(store)
+
+	store.EXPECT().Get(mock.Anything, "skip-cache-struct").Return(nil, ErrKeyNotExists).Twice()
+
+	predicateCalls := 0
+	predicate := func(v any) bool {
+		predicateCalls++
+		p, ok := v.(payload)
+		assert.True(t, ok)
+		assert.Equal(t, 204, p.Status)
+		return false
+	}
+
+	var out1 payload
+	err := cache.CacheStruct(t.Context(), "skip-cache-struct", time.Second, func(_ context.Context) (any, error) {
+		return payload{Status: 204}, nil
+	}, &out1, WithShouldCache(predicate))
+	assert.NoError(t, err)
+	assert.Equal(t, payload{Status: 204}, out1)
+
+	var out2 payload
+	err = cache.CacheStruct(t.Context(), "skip-cache-struct", time.Second, func(_ context.Context) (any, error) {
+		return payload{Status: 204}, nil
+	}, &out2, WithShouldCache(predicate))
+	assert.NoError(t, err)
+	assert.Equal(t, payload{Status: 204}, out2)
+	assert.Equal(t, 2, predicateCalls)
 }
 
 func TestCacheMetricHook_WarmUp(t *testing.T) {

--- a/request_options.go
+++ b/request_options.go
@@ -33,7 +33,7 @@ func WithTimeout(timeout time.Duration) CacheItemOptions {
 // WithShouldCache sets a predicate that decides whether the generated value should be cached.
 // The function takes the generated value as input and
 // returns true to cache it or false to skip caching.
-func WithShouldCache(shouldCache func([]byte) bool) CacheItemOptions {
+func WithShouldCache(shouldCache func(any) bool) CacheItemOptions {
 	if shouldCache == nil {
 		panic("shouldCache function cannot be nil")
 	}

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -86,8 +86,9 @@ func TestWithTimeout_ZeroDuration(t *testing.T) {
 
 func TestWithShouldCache_SetsPredicate(t *testing.T) {
 	req := &Request{}
-	predicate := func(value []byte) bool {
-		return len(value) > 0
+	predicate := func(value any) bool {
+		data, ok := value.([]byte)
+		return ok && len(data) > 0
 	}
 
 	WithShouldCache(predicate)(req)
@@ -98,7 +99,7 @@ func TestWithShouldCache_SetsPredicate(t *testing.T) {
 }
 
 func TestWithShouldCache_DoesNotAllowNilPredicate(t *testing.T) {
-	req := &Request{shouldCache: func([]byte) bool { return true }}
+	req := &Request{shouldCache: func(any) bool { return true }}
 
 	assert.PanicsWithValue(t, "shouldCache function cannot be nil", func() {
 		WithShouldCache(nil)(req)


### PR DESCRIPTION
This pull request introduces a more flexible conditional caching mechanism by generalizing the `WithShouldCache` predicate to accept any value type, not just `[]byte`. This allows users to decide whether to cache results based on the actual data type being generated (e.g., strings, structs). The change is accompanied by updates to the core caching logic, request handling, and comprehensive new tests to ensure correct behavior for all supported cache methods.

### Conditional caching improvements

* The `WithShouldCache` option now accepts a predicate of type `func(any) bool` instead of `func([]byte) bool`, enabling type-specific caching decisions for all cache variants (`Cache`, `CacheS`, `CacheStruct`). [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L61-R61) [[2]](diffhunk://#diff-13ada4577f84ede0e859377e18c34210d015b1d845fab5f9c451782bb0e35167L36-R36)
* The core cache methods (`Cache`, `CacheS`, `CacheStruct`) and their internal request handling have been refactored to pass the original generated value to the predicate, allowing richer conditional logic. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L100-R127) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L165-R192) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L187-R232)
* The documentation in `README.md` has been updated to describe the new behavior and clarify the value types passed to the predicate for each cache method. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129)

### Internal API and test updates

* All internal request handling and function signatures have been updated to consistently use a pointer to `Request` and accept the generalized predicate. [[1]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L272-R303) [[2]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L312-R343) [[3]](diffhunk://#diff-6531c53346d8c8061cbd9dcc08e2047e2aad3ac374e4912aaffa90d14faac561L383-R414)
* Existing tests have been updated to use the new predicate signature, and new tests have been added to verify that the correct value type is passed to the predicate for `CacheS` (string) and `CacheStruct` (struct/object). [[1]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL90-R94) [[2]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bL128-R128) [[3]](diffhunk://#diff-eb25628bf5c796eadd28ebdb283d5649ab6bc0dac083f7636fb605548516177bR153-R216) [[4]](diffhunk://#diff-09f6f7aed72aed48c7b11618921efb7ccdc5daab77ff12ffd90b1f74d2421f06L89-R91) [[5]](diffhunk://#diff-09f6f7aed72aed48c7b11618921efb7ccdc5daab77ff12ffd90b1f74d2421f06L101-R102)